### PR TITLE
add aspnet core project type features

### DIFF
--- a/src/CTA.FeatureDetection.Common/CTA.FeatureDetection.Common.csproj
+++ b/src/CTA.FeatureDetection.Common/CTA.FeatureDetection.Common.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codelyzer.Analysis" Version="1.2.36-alpha-gfac142e986" />
+    <PackageReference Include="Codelyzer.Analysis" Version="1.2.47-alpha-gacd3c02c4b" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/src/CTA.FeatureDetection.Common/Extensions/ProjectWorkspaceQueries.cs
+++ b/src/CTA.FeatureDetection.Common/Extensions/ProjectWorkspaceQueries.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Codelyzer.Analysis.Model;
 
@@ -26,6 +27,15 @@ namespace CTA.FeatureDetection.Common.Extensions
             => project.SourceFileResults
                 .SelectMany(n => n.AllClasses())
                 .Any(c => c.BaseTypeOriginalDefinition == typeOriginalDefinition);
+
+        /// <summary>
+        /// Gets class declaration nodes in a ProjectWorkspace with the specified base type
+        /// </summary>
+        /// <param name="project">ProjectWorkspace to search</param>
+        /// <param name="baseTypeOriginalDefinition">Original Definition of the base type being searched for</param>
+        /// <returns>Collection of class declaration nodes in the project with the specified base type</returns>
+        public static IEnumerable<UstNode> GetClassDeclarationsWithBaseType(this ProjectWorkspace project, string baseTypeOriginalDefinition)
+            => project.SourceFileResults.SelectMany(r => r.GetDeclaredClassesByBaseType(baseTypeOriginalDefinition));
 
         /// <summary>
         /// Determines if a specified directory exists in the project directory and is non-empty

--- a/src/CTA.FeatureDetection.Common/Extensions/ProjectWorkspaceQueries.cs
+++ b/src/CTA.FeatureDetection.Common/Extensions/ProjectWorkspaceQueries.cs
@@ -29,13 +29,22 @@ namespace CTA.FeatureDetection.Common.Extensions
                 .Any(c => c.BaseTypeOriginalDefinition == typeOriginalDefinition);
 
         /// <summary>
-        /// Gets class declaration nodes in a ProjectWorkspace with the specified base type
+        /// Gets all class declaration nodes in a ProjectWorkspace
         /// </summary>
         /// <param name="project">ProjectWorkspace to search</param>
-        /// <param name="baseTypeOriginalDefinition">Original Definition of the base type being searched for</param>
         /// <returns>Collection of class declaration nodes in the project with the specified base type</returns>
-        public static IEnumerable<UstNode> GetClassDeclarationsWithBaseType(this ProjectWorkspace project, string baseTypeOriginalDefinition)
-            => project.SourceFileResults.SelectMany(r => r.GetDeclaredClassesByBaseType(baseTypeOriginalDefinition));
+        public static IEnumerable<ClassDeclaration> GetAllClassDeclarations(this ProjectWorkspace project)
+            => project.SourceFileResults.SelectMany(r => r.AllClasses());
+
+        /// <summary>
+        /// Gets all class declaration nodes in a ProjectWorkspace derived from a specified base type
+        /// </summary>
+        /// <param name="project">ProjectWorkspace to search</param>
+        /// <param name="baseTypeOriginalDefinition">ProjectWorkspace to search</param>
+        /// <returns>Collection of class declaration nodes in the project with the specified base type</returns>
+        public static IEnumerable<ClassDeclaration> GetClassDeclarationsByBaseType(this ProjectWorkspace project, 
+            string baseTypeOriginalDefinition)
+            => project.GetAllClassDeclarations().Where(c => c.HasBaseType(baseTypeOriginalDefinition));
 
         /// <summary>
         /// Determines if a specified directory exists in the project directory and is non-empty

--- a/src/CTA.FeatureDetection.Common/Extensions/UstNodeQueries.cs
+++ b/src/CTA.FeatureDetection.Common/Extensions/UstNodeQueries.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Codelyzer.Analysis;
 using Codelyzer.Analysis.Model;
 
 namespace CTA.FeatureDetection.Common.Extensions
@@ -26,6 +25,26 @@ namespace CTA.FeatureDetection.Common.Extensions
         public static IEnumerable<UstNode> GetInvocationExpressionsBySemanticDefinition(this UstNode node,
                 string semanticOriginalDefinition)
             => node.AllInvocationExpressions().Where(i => i.SemanticOriginalDefinition == semanticOriginalDefinition);
+
+        /// <summary>
+        /// Searches a syntax tree to identify all invocation expression nodes with a specified semantic return type
+        /// </summary>
+        /// <param name="node">Syntax tree node to start searching from</param>
+        /// <param name="semanticReturnType">Semantic return type to look for</param>
+        /// <returns>Collection of invocation expression nodes with the specified semantic return type</returns>
+        public static IEnumerable<UstNode> GetInvocationExpressionsBySemanticReturnType(this UstNode node,
+                string semanticReturnType)
+            => node.AllInvocationExpressions().Where(i => i.SemanticReturnType == semanticReturnType);
+
+        /// <summary>
+        /// Searches a syntax tree to identify all invocation expression nodes with any of the specified semantic return types
+        /// </summary>
+        /// <param name="node">Syntax tree node to start searching from</param>
+        /// <param name="semanticReturnTypes">Semantic return types to look for</param>
+        /// <returns>Collection of invocation expression nodes with any of the specified semantic return types</returns>
+        public static IEnumerable<UstNode> GetInvocationExpressionsBySemanticReturnType(this UstNode node,
+                IEnumerable<string> semanticReturnTypes)
+            => node.AllInvocationExpressions().Where(i => semanticReturnTypes.Contains(i.SemanticReturnType));
 
         /// <summary>
         /// Determines if a syntax tree has any invocation expression nodes with the specified semantic definition

--- a/src/CTA.FeatureDetection.Common/Extensions/UstNodeQueries.cs
+++ b/src/CTA.FeatureDetection.Common/Extensions/UstNodeQueries.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Codelyzer.Analysis.Model;
 
@@ -6,6 +7,8 @@ namespace CTA.FeatureDetection.Common.Extensions
 {
     public static class UstNodeQueries
     {
+        private static string PublicAccessor => "public";
+
         /// <summary>
         /// Searches a syntax tree to identify all class declaration nodes with a specified base type
         /// </summary>
@@ -47,6 +50,14 @@ namespace CTA.FeatureDetection.Common.Extensions
             => node.AllInvocationExpressions().Where(i => semanticReturnTypes.Contains(i.SemanticReturnType));
 
         /// <summary>
+        /// Searches a syntax tree to identify all method declarations with the public accessor
+        /// </summary>
+        /// <param name="node">Syntax tree node to start searching from</param>
+        /// <returns>Collection of method declarations with the public accessor</returns>
+        public static IEnumerable<UstNode> GetPublicMethodDeclarations(this UstNode node)
+            => node.AllMethods().Where(m => m.IsPublic());
+
+        /// <summary>
         /// Determines if a syntax tree has any invocation expression nodes with the specified semantic definition
         /// </summary>
         /// <param name="node">Syntax tree node to start searching from</param>
@@ -75,5 +86,31 @@ namespace CTA.FeatureDetection.Common.Extensions
         /// <returns>Whether or not a reference is being used in the syntax tree</returns>
         public static bool ContainsReference(this RootUstNode node, string referenceIdentifier)
             => node.References.Any(r => r.Namespace == referenceIdentifier);
+
+        /// <summary>
+        /// Determines whether or not a MethodDeclaration is public
+        /// </summary>
+        /// <param name="node">BaseMethodDeclaration node with SemanticProperties</param>
+        /// <returns>Whether or not the node has a public accessor</returns>
+        public static bool IsPublic(this BaseMethodDeclaration node)
+            => node.SemanticProperties.Any(p => p.Equals(PublicAccessor, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Determines whether or not a node has the specified base type
+        /// </summary>
+        /// <param name="node">Node to query</param>
+        /// <param name="baseTypeOriginalDefinition">Original Definition of the base type being searched for</param>
+        /// <returns>Whether or not the class declaration node has the specified base type</returns>
+        public static bool HasBaseType(this ClassDeclaration node, string baseTypeOriginalDefinition)
+            => node.BaseTypeOriginalDefinition.Equals(baseTypeOriginalDefinition, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Determines whether or not a node has the specified attribute
+        /// </summary>
+        /// <param name="node">Node to query</param>
+        /// <param name="attributeType">Semantic type of attribute being searched for</param>
+        /// <returns>Whether or not the class declaration node has the specified attribute</returns>
+        public static bool HasAttribute(this UstNode node, string attributeType)
+            => node.AllAnnotations().Any(a => a.SemanticClassType.Equals(attributeType, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/CTA.FeatureDetection.ProjectType/CTA.FeatureDetection.ProjectType.csproj
+++ b/src/CTA.FeatureDetection.ProjectType/CTA.FeatureDetection.ProjectType.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codelyzer.Analysis" Version="1.2.36-alpha-gfac142e986" />
+    <PackageReference Include="Codelyzer.Analysis" Version="1.2.47-alpha-gacd3c02c4b" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CTA.FeatureDetection.ProjectType/CompiledFeatures/AspNetCoreMvcFeature.cs
+++ b/src/CTA.FeatureDetection.ProjectType/CompiledFeatures/AspNetCoreMvcFeature.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using Codelyzer.Analysis;
+using CTA.FeatureDetection.Common.Extensions;
+using CTA.FeatureDetection.Common.Models.Features.Base;
+
+namespace CTA.FeatureDetection.ProjectType.CompiledFeatures
+{
+    public class AspNetCoreMvcFeature : CompiledFeature
+    {
+        /// <summary>
+        /// Determines that a project is an ASP.NET Core MVC project if:
+        ///     1) Any class derived from the Controller abstract class also calls any method returning a view-related object
+        ///     AND
+        ///     2) The project contains a non-empty Views directory
+        /// </summary>
+        /// <param name="analyzerResult"></param>
+        /// <returns>Whether a project is an ASP.NET Core MVC project or not</returns>
+        public override bool IsPresent(AnalyzerResult analyzerResult)
+        {
+            var project = analyzerResult.ProjectResult;
+            var controllerClassDeclarations = project.GetClassDeclarationsWithBaseType(Constants.NetCoreMvcControllerOriginalDefinition);
+            var returnsViewObjectFromControllerClasses = controllerClassDeclarations.Any(c => c.GetInvocationExpressionsBySemanticReturnType(Constants.NetCoreViewResultTypes).Any());
+
+            var isPresent = returnsViewObjectFromControllerClasses
+                && project.ContainsNonEmptyDirectory(Constants.MvcViewsDirectory);
+
+            return isPresent;
+        }
+    }
+}

--- a/src/CTA.FeatureDetection.ProjectType/CompiledFeatures/AspNetCoreWebApiFeature.cs
+++ b/src/CTA.FeatureDetection.ProjectType/CompiledFeatures/AspNetCoreWebApiFeature.cs
@@ -1,0 +1,33 @@
+﻿using Codelyzer.Analysis;
+using CTA.FeatureDetection.Common.Extensions;
+using CTA.FeatureDetection.Common.Models.Features.Base;
+using System.Linq;
+
+namespace CTA.FeatureDetection.ProjectType.CompiledFeatures
+{
+    public class AspNetCoreWebApiFeature : CompiledFeature
+    {
+        /// <summary>
+        /// Determines that a project is an ASP.NET Core WebAPi project if:
+        ///     1) There are any classes derived from the ControllerBase abstract class
+        ///        and no classes derived from the Controller abstract class
+        ///     OR
+        ///     2) If there are any classes derived from the Controller abstract class,
+        ///        none of them call any methods that return a view-related object.
+        /// </summary>
+        /// <param name="analyzerResult"></param>
+        /// <returns>Whether a project is an ASP.NET Core WebApi project or not</returns>
+        public override bool IsPresent(AnalyzerResult analyzerResult)
+        {
+            var project = analyzerResult.ProjectResult;
+            var controllerBaseClassDeclarations = project.GetClassDeclarationsWithBaseType(Constants.NetCoreMvcControllerBaseOriginalDefinition);
+            var controllerClassDeclarations = project.GetClassDeclarationsWithBaseType(Constants.NetCoreMvcControllerOriginalDefinition);
+            var returnsViewObjectFromControllerClasses = controllerClassDeclarations.Any(c => c.GetInvocationExpressionsBySemanticReturnType(Constants.NetCoreViewResultTypes).Any());
+
+            var isPresent = (controllerBaseClassDeclarations.Any() && !controllerClassDeclarations.Any())
+                            || (controllerClassDeclarations.Any() && !returnsViewObjectFromControllerClasses);
+
+            return isPresent;
+        }
+    }
+}

--- a/src/CTA.FeatureDetection.ProjectType/Constants.cs
+++ b/src/CTA.FeatureDetection.ProjectType/Constants.cs
@@ -7,13 +7,14 @@
             "ViewResult",
             "PartialViewResult"
         };
+        public const string ApiControllerAttributeType = "ApiControllerAttribute";
         public const string NetCoreMvcControllerOriginalDefinition = "Microsoft.AspNetCore.Mvc.Controller";
         public const string NetCoreMvcControllerBaseOriginalDefinition = "Microsoft.AspNetCore.Mvc.ControllerBase";
+        public const string MvcControllerOriginalDefinition = "System.Web.Mvc.Controller";
+        public const string WebApiControllerOriginalDefinition = "System.Web.Http.ApiController";
         public const string SystemWebReferenceIdentifier = "System.Web";
         public const string WebApiNugetReferenceIdentifier = "Microsoft.AspNet.WebApi";
-        public const string WebApiControllerOriginalDefinition = "System.Web.Http.ApiController";
         public const string MvcNugetReferenceIdentifier = "Microsoft.AspNet.Mvc";
-        public const string MvcControllerOriginalDefinition = "System.Web.Mvc.Controller";
         public const string MvcViewsDirectory = "Views";
 
         public const string AspNetMvcFeatureName = "AspNetMvcFeature";

--- a/src/CTA.FeatureDetection.ProjectType/Constants.cs
+++ b/src/CTA.FeatureDetection.ProjectType/Constants.cs
@@ -2,6 +2,13 @@
 {
     public class Constants
     {
+        public static readonly string[] NetCoreViewResultTypes = {
+            "ViewComponentResult",
+            "ViewResult",
+            "PartialViewResult"
+        };
+        public const string NetCoreMvcControllerOriginalDefinition = "Microsoft.AspNetCore.Mvc.Controller";
+        public const string NetCoreMvcControllerBaseOriginalDefinition = "Microsoft.AspNetCore.Mvc.ControllerBase";
         public const string SystemWebReferenceIdentifier = "System.Web";
         public const string WebApiNugetReferenceIdentifier = "Microsoft.AspNet.WebApi";
         public const string WebApiControllerOriginalDefinition = "System.Web.Http.ApiController";
@@ -12,5 +19,7 @@
         public const string AspNetMvcFeatureName = "AspNetMvcFeature";
         public const string AspNetWebApiFeatureName = "AspNetWebApiFeature";
         public const string WebClassLibraryFeatureName = "WebClassLibraryFeature";
+        public const string AspNetCoreMvcFeatureName = "AspNetCoreMvcFeature";
+        public const string AspNetCoreWebApiFeatureName = "AspNetCoreWebApiFeature";
     }
 }

--- a/src/CTA.FeatureDetection.ProjectType/Extensions/FeatureDetectionResultQueries.cs
+++ b/src/CTA.FeatureDetection.ProjectType/Extensions/FeatureDetectionResultQueries.cs
@@ -6,20 +6,40 @@ namespace CTA.FeatureDetection.ProjectType.Extensions
     public static class FeatureDetectionResultQueries
     {
         /// <summary>
-        /// Queries a FeatureDetectionResult object to determine if the project is a WebAPI project
+        /// Queries a FeatureDetectionResult object to determine if the project is a .NET Core WebAPI project
         /// </summary>
         /// <param name="featureDetectionResult">Result from feature detection</param>
-        /// <returns>Whether or not the project is a WebAPI project</returns>
+        /// <returns>Whether or not the project is a .NET Core WebAPI project</returns>
+        public static bool IsCoreWebApiProject(this FeatureDetectionResult featureDetectionResult)
+        {
+            return featureDetectionResult.FeatureStatus.GetValueOrDefault(Constants.AspNetCoreWebApiFeatureName, false);
+        }
+
+        /// <summary>
+        /// Queries a FeatureDetectionResult object to determine if the project is a .NET Core MVC project
+        /// </summary>
+        /// <param name="featureDetectionResult">Result from feature detection</param>
+        /// <returns>Whether or not the project is a .NET Core MVC project</returns>
+        public static bool IsCoreMvcProject(this FeatureDetectionResult featureDetectionResult)
+        { 
+            return featureDetectionResult.FeatureStatus.GetValueOrDefault(Constants.AspNetCoreMvcFeatureName, false);
+        }
+
+        /// <summary>
+        /// Queries a FeatureDetectionResult object to determine if the project is a .NET Framework WebAPI project
+        /// </summary>
+        /// <param name="featureDetectionResult">Result from feature detection</param>
+        /// <returns>Whether or not the project is a .NET Framework WebAPI project</returns>
         public static bool IsWebApiProject(this FeatureDetectionResult featureDetectionResult)
         {
             return featureDetectionResult.FeatureStatus.GetValueOrDefault(Constants.AspNetWebApiFeatureName, false);
         }
 
         /// <summary>
-        /// Queries a FeatureDetectionResult object to determine if the project is an MVC project
+        /// Queries a FeatureDetectionResult object to determine if the project is a .NET Framework MVC project
         /// </summary>
         /// <param name="featureDetectionResult">Result from feature detection</param>
-        /// <returns>Whether or not the project is an MVC project</returns>
+        /// <returns>Whether or not the project is a .NET Framework MVC project</returns>
         public static bool IsMvcProject(this FeatureDetectionResult featureDetectionResult)
         { 
             return featureDetectionResult.FeatureStatus.GetValueOrDefault(Constants.AspNetMvcFeatureName, false);

--- a/src/CTA.FeatureDetection/Program.cs
+++ b/src/CTA.FeatureDetection/Program.cs
@@ -11,13 +11,10 @@ namespace CTA.FeatureDetection
         static void Main(string[] args)
         {
             /* Select a test project */
-            //var solutionPath = Path.Combine("..", "..", "..", "..", "FeatureDetection.Tests", "Examples", "Projects", "ProjectType_Test", "ProjectType_Test.sln");
-            //var solutionPath = Path.Combine("..", "..", "..", "..", "FeatureDetection.Tests", "Examples", "Projects", "EF6_Test", "EF6_Test.sln");
-            var solutionPath = Path.Combine("..", "..", "..", "..", "FeatureDetection.Tests", "Examples", "Projects", "Test_Solution_For_FeatureDetection", "Test_Solution_For_FeatureDetection.sln");
+            var solutionPath = Path.Combine("oath", "to", "solution.sln");
 
             /* Select a feature config file*/
-            var featureConfigFilePath = Path.Combine("..", "..", "..", "..", "FeatureDetection.Tests", "Examples", "Input", "feature_config.json");
-
+            var featureConfigFilePath = Path.Combine("..", "..", "..", "..", "..", "tst", "CTA.FeatureDetection.Tests", "Examples", "Input", "feature_config.json");
 
             // Identify all features in a given project
             var featureDetector = new FeatureDetector(featureConfigFilePath);

--- a/src/CTA.FeatureDetection/Program.cs
+++ b/src/CTA.FeatureDetection/Program.cs
@@ -11,7 +11,7 @@ namespace CTA.FeatureDetection
         static void Main(string[] args)
         {
             /* Select a test project */
-            var solutionPath = Path.Combine("oath", "to", "solution.sln");
+            var solutionPath = Path.Combine("path", "to", "solution.sln");
 
             /* Select a feature config file*/
             var featureConfigFilePath = Path.Combine("..", "..", "..", "..", "..", "tst", "CTA.FeatureDetection.Tests", "Examples", "Input", "feature_config.json");

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.Common/Extensions/ProjectWorkspaceQueriesTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.Common/Extensions/ProjectWorkspaceQueriesTests.cs
@@ -47,6 +47,17 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.Common.Extensions
         }
 
         [Test]
+        public void GetAllClassDeclarations_Returns_All_Class_Declaration_Nodes_In_Project()
+        {
+            var projectName = MvcProjectName;
+            var projectWorkspace = MvcAnalyzerResults
+                .First(r => r.ProjectResult.ProjectName == projectName)
+                .ProjectResult;
+
+            Assert.AreEqual(5, projectWorkspace.GetAllClassDeclarations().Count());
+        }
+
+        [Test]
         public void ContainsNonEmptyDirectory_Returns_True_If_Directory_Is_Found_With_Contents()
         {
             var directoryName = "Views";

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.Common/Extensions/UstNodeQueriesTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.Common/Extensions/UstNodeQueriesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Codelyzer.Analysis.Model;
 using CTA.FeatureDetection.Common.Extensions;
 using CTA.FeatureDetection.Tests.TestBase;
 using NUnit.Framework;
@@ -50,6 +51,20 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.Common.Extensions
                 .First(r => r.FilePath.EndsWith(sourceFileName));
 
             Assert.IsEmpty(node.GetInvocationExpressionsBySemanticDefinition(semanticOriginalDefinition));
+        }
+
+        [Test]
+        public void GetPublicMethodDeclarations_Returns_Collection_Of_Public_MethodDeclarations()
+        {
+            var projectName = MvcProjectName;
+            var sourceFileName = "HomeController.cs";
+            var projectWorkspace = MvcAnalyzerResults
+                .First(r => r.ProjectResult.ProjectName == projectName)
+                .ProjectResult;
+            var node = projectWorkspace.SourceFileResults
+                .First(r => r.FilePath.EndsWith(sourceFileName));
+
+            Assert.AreEqual(3, node.GetPublicMethodDeclarations().Count());
         }
 
         [Test]
@@ -144,6 +159,62 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.Common.Extensions
 
             Assert.False(node.ContainsUsingDirectiveWithIdentifier(identifier),
                 $"Unexpected UsingDirective {identifier} in {projectName}//{sourceFileName} was found.");
+        }
+
+        [Test]
+        public void IsPublic_Returns_True_If_MethodDeclaration_Has_Public_Modifier()
+        {
+            var projectName = MvcProjectName;
+            var sourceFileName = "HomeController.cs";
+            var methodName = "Index";
+            var projectWorkspace = MvcAnalyzerResults
+                .First(r => r.ProjectResult.ProjectName == projectName)
+                .ProjectResult;
+            var node = projectWorkspace.SourceFileResults
+                .First(r => r.FilePath.EndsWith(sourceFileName))
+                .AllMethods()
+                .First(m => m.Identifier.Equals(methodName));
+
+            Assert.True(node.IsPublic(),
+                $"Expected {methodName} method in {projectName}//{sourceFileName} to be public.");
+        }
+
+        [Test]
+        public void HasBaseType_Returns_True_If_ClassDeclaration_Is_Derived_From_BaseType()
+        {
+            var projectName = MvcProjectName;
+            var sourceFileName = "HomeController.cs";
+            var className = "HomeController";
+            var baseType = "System.Web.Mvc.Controller";
+            var projectWorkspace = MvcAnalyzerResults
+                .First(r => r.ProjectResult.ProjectName == projectName)
+                .ProjectResult;
+            var node = projectWorkspace.SourceFileResults
+                .First(r => r.FilePath.EndsWith(sourceFileName))
+                .AllClasses()
+                .First(m => m.Identifier.Equals(className));
+
+            Assert.True(node.HasBaseType(baseType),
+                $"Expected {className} class in {projectName}//{sourceFileName} to inherit from {baseType}.");
+        }
+
+        [Test]
+        public void HasAttribute_Returns_True_If_Node_Has_The_Specified_Attribute()
+        {
+            var projectName = WebApiProjectName;
+            var sourceFileName = "ValuesController.cs";
+            var className = "ValuesController";
+            var attributeType = "FromBodyAttribute";
+            var projectWorkspace = WebApiAnalyzerResults
+                .First(r => r.ProjectResult.ProjectName == projectName)
+                .ProjectResult;
+            var node = projectWorkspace.SourceFileResults
+                .First(r => r.FilePath.EndsWith(sourceFileName))
+                .AllClasses()
+                .First(m => m.Identifier.Equals(className));
+
+            Assert.True(node.HasAttribute(attributeType),
+                $"Expected {className} class in {projectName}//{sourceFileName} to have attribute {attributeType}.");
         }
     }
 }

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.Common/Extensions/UstNodeQueriesTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.Common/Extensions/UstNodeQueriesTests.cs
@@ -85,6 +85,36 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.Common.Extensions
         }
 
         [Test]
+        public void GetInvocationExpressionsBySemanticReturnType_Returns_InvocationExpressions_With_SemanticReturnType()
+        {
+            var semanticReturnType = "ViewResult";
+            var projectName = MvcProjectName; 
+            var sourceFileName = "HomeController.cs";
+            var projectWorkspace = MvcAnalyzerResults
+                .First(r => r.ProjectResult.ProjectName == projectName)
+                .ProjectResult;
+            var node = projectWorkspace.SourceFileResults
+                .First(r => r.FilePath.EndsWith(sourceFileName));
+
+            Assert.True(node.GetInvocationExpressionsBySemanticReturnType(semanticReturnType).Count() == 3);
+        }
+
+        [Test]
+        public void GetInvocationExpressionsBySemanticReturnType_Returns_InvocationExpressions_With_SemanticReturnTypes()
+        {
+            var semanticReturnTypes = new[] {"ViewResult"};
+            var projectName = MvcProjectName; 
+            var sourceFileName = "HomeController.cs";
+            var projectWorkspace = MvcAnalyzerResults
+                .First(r => r.ProjectResult.ProjectName == projectName)
+                .ProjectResult;
+            var node = projectWorkspace.SourceFileResults
+                .First(r => r.FilePath.EndsWith(sourceFileName));
+
+            Assert.True(node.GetInvocationExpressionsBySemanticReturnType(semanticReturnTypes).Count() == 3);
+        }
+
+        [Test]
         public void ContainsUsingDirectiveWithIdentifier_Returns_True_If_UsingDirective_Is_Found()
         {
             var identifier = "System.Web.Mvc";

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.Load/Loaders/FeatureLoaderTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.Load/Loaders/FeatureLoaderTests.cs
@@ -19,7 +19,14 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.Load.Loaders
             var loadedFeatures = FeatureLoader.LoadFeaturesFromNamespace(assembly, namespaceSuffix);
             var loadedFeatureNames = loadedFeatures.Select(f => f.Name);
 
-            var expectedFeatureNames = new[] { nameof(AspNetMvcFeature), nameof(AspNetWebApiFeature), nameof(WebClassLibraryFeature) };
+            var expectedFeatureNames = new[]
+            {
+                nameof(AspNetMvcFeature), 
+                nameof(AspNetWebApiFeature), 
+                nameof(AspNetCoreMvcFeature), 
+                nameof(AspNetCoreWebApiFeature), 
+                nameof(WebClassLibraryFeature)
+            };
 
             CollectionAssert.AreEquivalent(expectedFeatureNames, loadedFeatureNames);
         }

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/Extensions/FeatureDetectionResultQueriesTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/Extensions/FeatureDetectionResultQueriesTests.cs
@@ -8,6 +8,28 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.ProjectType.Extensions
     public class FeatureDetectionResultQueriesTests
     {
         [Test]
+        public void IsNetCoreMvcProject_Returns_True_If_NetCoreMvcFeature_Is_Present()
+        {
+            var mockResult = new FeatureDetectionResult
+            {
+                FeatureStatus = {{Constants.AspNetCoreMvcFeatureName, true}}
+            };
+
+            Assert.True(mockResult.IsCoreMvcProject());
+        }
+
+        [Test]
+        public void IsNetCoreWebApiProject_Returns_True_If_NetCoreWebApiFeature_Is_Present()
+        {
+            var mockResult = new FeatureDetectionResult
+            {
+                FeatureStatus = { { Constants.AspNetCoreWebApiFeatureName, true } }
+            };
+
+            Assert.True(mockResult.IsCoreWebApiProject());
+        }
+
+        [Test]
         public void IsMvcProject_Returns_True_If_MvcFeature_Is_Present()
         {
             var mockResult = new FeatureDetectionResult

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/ProjectTypeFeatureDetectionTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/ProjectTypeFeatureDetectionTests.cs
@@ -11,6 +11,10 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.ProjectType
             var featureName = "AspNetCoreMvcFeature";
             Assert.True(_coreMvcFeatureDetectionResult.FeatureStatus[featureName],
                 $"Expected project type of {CoreMvcProjectName} to be CoreMVC.");
+
+            featureName = "AspNetCoreWebApiFeature";
+            Assert.False(_coreMvcFeatureDetectionResult.FeatureStatus[featureName],
+                $"Expected project type of {CoreMvcProjectName} to not be CoreWebApi.");
         }
 
         [Test]
@@ -19,6 +23,10 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.ProjectType
             var featureName = "AspNetCoreWebApiFeature";
             Assert.True(_coreWebApiFeatureDetectionResult.FeatureStatus[featureName],
                 $"Expected project type of {CoreWebApiProjectName} to be CoreWebApi.");
+
+            featureName = "AspNetCoreMvcFeature";
+            Assert.False(_coreWebApiFeatureDetectionResult.FeatureStatus[featureName],
+                $"Expected project type of {CoreWebApiProjectName} to not be CoreMvc.");
         }
 
         [Test]

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/ProjectTypeFeatureDetectionTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/ProjectTypeFeatureDetectionTests.cs
@@ -6,6 +6,22 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.ProjectType
     public class ProjectTypeFeatureDetectionTests : DetectAllFeaturesTestBase
     {
         [Test]
+        public void AspnetCoreMvcFeature_Is_Present_In_CoreMvc_Project()
+        {
+            var featureName = "AspNetCoreMvcFeature";
+            Assert.True(_coreMvcFeatureDetectionResult.FeatureStatus[featureName],
+                $"Expected project type of {CoreMvcProjectName} to be CoreMVC.");
+        }
+
+        [Test]
+        public void AspnetCoreWebApiFeature_Is_Present_In_CoreWebApi_Project()
+        {
+            var featureName = "AspNetCoreWebApiFeature";
+            Assert.True(_coreWebApiFeatureDetectionResult.FeatureStatus[featureName],
+                $"Expected project type of {CoreWebApiProjectName} to be CoreWebApi.");
+        }
+
+        [Test]
         public void AspnetMvcFeature_Is_Present_In_Mvc_Project()
         {
             var featureName = "AspNetMvcFeature";

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/ProjectTypeFeatureDetectionTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/ProjectTypeFeatureDetectionTests.cs
@@ -13,8 +13,8 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.ProjectType
                 $"Expected project type of {CoreMvcProjectName} to be CoreMVC.");
 
             featureName = "AspNetCoreWebApiFeature";
-            Assert.True(_coreMvcFeatureDetectionResult.FeatureStatus[featureName],
-                $"Expected project type of {CoreMvcProjectName} to not be CoreWebApi.");
+            Assert.False(_coreMvcFeatureDetectionResult.FeatureStatus[featureName],
+                $"Expected project type of {CoreMvcProjectName} to be CoreWebApi.");
         }
 
         [Test]

--- a/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/ProjectTypeFeatureDetectionTests.cs
+++ b/tst/CTA.FeatureDetection.Tests/CTA.FeatureDetection.ProjectType/ProjectTypeFeatureDetectionTests.cs
@@ -13,7 +13,7 @@ namespace CTA.FeatureDetection.Tests.FeatureDetection.ProjectType
                 $"Expected project type of {CoreMvcProjectName} to be CoreMVC.");
 
             featureName = "AspNetCoreWebApiFeature";
-            Assert.False(_coreMvcFeatureDetectionResult.FeatureStatus[featureName],
+            Assert.True(_coreMvcFeatureDetectionResult.FeatureStatus[featureName],
                 $"Expected project type of {CoreMvcProjectName} to not be CoreWebApi.");
         }
 

--- a/tst/CTA.FeatureDetection.Tests/Examples/Input/feature_config.json
+++ b/tst/CTA.FeatureDetection.Tests/Examples/Input/feature_config.json
@@ -18,6 +18,14 @@
                   "ClassName": "AspNetWebApiFeature"
                 },
                 {
+                  "Name": "AspNetCoreMvcFeature",
+                  "ClassName": "AspNetCoreMvcFeature"
+                },
+                {
+                  "Name": "AspNetCoreWebApiFeature",
+                  "ClassName": "AspNetCoreWebApiFeature"
+                },
+                {
                   "Name": "WebClassLibraryFeature",
                   "ClassName": "WebClassLibraryFeature"
                 }

--- a/tst/CTA.FeatureDetection.Tests/Fixtures/TestProjectsSetupFixture.cs
+++ b/tst/CTA.FeatureDetection.Tests/Fixtures/TestProjectsSetupFixture.cs
@@ -16,6 +16,8 @@ namespace CTA.FeatureDetection.Tests
         private string _tempDirName;
         private string _tempBaseDir;
         private static string _targetDir;
+        private static readonly string _coreMvcDir = "CoreMVC";
+        private static readonly string _coreWebApiDir = "CoreWebApi";
         private static readonly string _efDir = "Ef";
         private static readonly string _mvcDir = "Mvc";
         private static readonly string _webApiDir = "WebApi";
@@ -23,23 +25,33 @@ namespace CTA.FeatureDetection.Tests
         private static readonly string TestProjectDirectory = TestUtils.GetTestAssemblySourceDirectory(typeof(TestUtils));
         public static string ConfigFile => Path.Combine(TestProjectDirectory, "Examples", "Input", "feature_config.json");
 
+        public static string CoreMvcSolutionName => "CoreMVC.sln";
+        public static string CoreWebApiSolutionName => "CoreWebApi.sln";
         public static string EfSolutionName => "EF6_Test.sln";
         public static string MvcSolutionName => "ASP.NET-MVC-Framework.sln";
         public static string WebApiSolutionName => "WebApi-Framework.sln";
         public static string WebClassLibrarySolutionName => "WebClassLibrary.sln";
+        public static string CoreMvcSolutionPath => Path.Combine(_targetDir, _coreMvcDir, CoreMvcSolutionName);
+        public static string CoreWebApiSolutionPath => Path.Combine(_targetDir, _coreWebApiDir, CoreWebApiSolutionName);
         public static string EfSolutionPath => Path.Combine(_targetDir, _efDir, EfSolutionName);
         public static string MvcSolutionPath => Path.Combine(_targetDir, _mvcDir, MvcSolutionName);
         public static string WebApiSolutionPath => Path.Combine(_targetDir, _webApiDir, WebApiSolutionName);
         public static string WebClassLibrarySolutionPath => Path.Combine(_targetDir, _webClassLibraryDir, WebClassLibrarySolutionName);
+        public static string CoreMvcProjectPath => Path.Combine(_targetDir, _coreMvcDir, "CoreMVC", "CoreMVC.csproj");
+        public static string CoreWebApiProjectPath => Path.Combine(_targetDir, _coreWebApiDir, "CoreWebApi", "CoreWebApi.csproj");
         public static string Ef6ProjectPath => Path.Combine(_targetDir, _efDir, "EF6_Test", "EF6_Test.csproj");
         public static string MvcProjectPath => Path.Combine(_targetDir, _mvcDir, "ASP.NET-MVC-Framework", "ASP.NET-MVC-Framework.csproj");
         public static string WebApiProjectPath => Path.Combine(_targetDir, _webApiDir, "WebApi-Framework", "WebApi-Framework.csproj");
         public static string WebClassLibraryProjectPath => Path.Combine(_targetDir, _webClassLibraryDir, "WebClassLibrary", "WebClassLibrary.csproj");
+        public static IEnumerable<AnalyzerResult> CoreMvcAnalyzerResults { get; private set; }
+        public static IEnumerable<AnalyzerResult> CoreWebApiAnalyzerResults { get; private set; }
         public static IEnumerable<AnalyzerResult> EfAnalyzerResults { get; private set; }
         public static IEnumerable<AnalyzerResult> MvcAnalyzerResults { get; private set; }
         public static IEnumerable<AnalyzerResult> WebApiAnalyzerResults { get; private set; }
         public static IEnumerable<AnalyzerResult> WebClassLibraryAnalyzerResults { get; private set; }
         public static FeatureDetector FeatureDetector { get; private set; }
+        public static FeatureDetectionResult CoreMvcFeatureDetectionResult { get; private set; }
+        public static FeatureDetectionResult CoreWebApiFeatureDetectionResult { get; private set; }
         public static FeatureDetectionResult Ef6FeatureDetectionResult { get; private set; }
         public static FeatureDetectionResult MvcFeatureDetectionResult { get; private set; }
         public static FeatureDetectionResult WebApiFeatureDetectionResult { get; private set; }
@@ -56,20 +68,26 @@ namespace CTA.FeatureDetection.Tests
             DownloadTestProjects(tempDownloadDir);
 
             // Get directory of each solution
+            var tempCoreMvcSolutionDir = GetSolutionDir(tempDownloadDir, CoreMvcSolutionName);
+            var tempCoreWebApiSolutionDir = GetSolutionDir(tempDownloadDir, CoreWebApiSolutionName);
             var tempEfSolutionDir = GetSolutionDir(tempDownloadDir, EfSolutionName);
             var tempMvcSolutionDir = GetSolutionDir(tempDownloadDir, MvcSolutionName);
             var tempWebApiSolutionDir = GetSolutionDir(tempDownloadDir, WebApiSolutionName);
             var tempWebClassLibrarySolutionDir = GetSolutionDir(tempDownloadDir, WebClassLibrarySolutionName);
             
             // Copy solutions to a directory with a shorter path
-            var frameworkVersion = "net472";
-            _targetDir = Path.Combine(_tempBaseDir, frameworkVersion);
+            var destDir = "dest";
+            _targetDir = Path.Combine(_tempBaseDir, destDir);
+            TestUtils.CopyDirectory(tempCoreMvcSolutionDir, new DirectoryInfo(Path.Combine(_targetDir, _coreMvcDir)));
+            TestUtils.CopyDirectory(tempCoreWebApiSolutionDir, new DirectoryInfo(Path.Combine(_targetDir, _coreWebApiDir)));
             TestUtils.CopyDirectory(tempEfSolutionDir, new DirectoryInfo(Path.Combine(_targetDir, _efDir)));
             TestUtils.CopyDirectory(tempMvcSolutionDir, new DirectoryInfo(Path.Combine(_targetDir, _mvcDir)));
             TestUtils.CopyDirectory(tempWebApiSolutionDir, new DirectoryInfo(Path.Combine(_targetDir, _webApiDir)));
             TestUtils.CopyDirectory(tempWebClassLibrarySolutionDir, new DirectoryInfo(Path.Combine(_targetDir, _webClassLibraryDir)));
 
             // Run source code analysis
+            CoreMvcAnalyzerResults = AnalyzerResultsFactory.GetAnalyzerResults(CoreMvcSolutionPath);
+            CoreWebApiAnalyzerResults = AnalyzerResultsFactory.GetAnalyzerResults(CoreWebApiSolutionPath);
             EfAnalyzerResults = AnalyzerResultsFactory.GetAnalyzerResults(EfSolutionPath);
             MvcAnalyzerResults = AnalyzerResultsFactory.GetAnalyzerResults(MvcSolutionPath);
             WebApiAnalyzerResults = AnalyzerResultsFactory.GetAnalyzerResults(WebApiSolutionPath);
@@ -77,6 +95,8 @@ namespace CTA.FeatureDetection.Tests
 
             // Detect features in each solution
             FeatureDetector = new FeatureDetector(ConfigFile);
+            CoreMvcFeatureDetectionResult = FeatureDetector.DetectFeaturesInProjects(CoreMvcAnalyzerResults)[CoreMvcProjectPath];
+            CoreWebApiFeatureDetectionResult = FeatureDetector.DetectFeaturesInProjects(CoreWebApiAnalyzerResults)[CoreWebApiProjectPath];
             Ef6FeatureDetectionResult = FeatureDetector.DetectFeaturesInProjects(EfAnalyzerResults)[Ef6ProjectPath];
             MvcFeatureDetectionResult = FeatureDetector.DetectFeaturesInProjects(MvcAnalyzerResults)[MvcProjectPath];
             WebApiFeatureDetectionResult = FeatureDetector.DetectFeaturesInProjects(WebApiAnalyzerResults)[WebApiProjectPath];

--- a/tst/CTA.FeatureDetection.Tests/TestBase/DetectAllFeaturesTestBase.cs
+++ b/tst/CTA.FeatureDetection.Tests/TestBase/DetectAllFeaturesTestBase.cs
@@ -18,11 +18,15 @@ namespace CTA.FeatureDetection.Tests.TestBase
         protected static FeatureDetector FeatureDetector { get; private set; }
         protected static string TestProjectDirectory { get; private set; }
 
+        protected FeatureDetectionResult _coreMvcFeatureDetectionResult;
+        protected FeatureDetectionResult _coreWebApiFeatureDetectionResult;
         protected FeatureDetectionResult _ef6FeatureDetectionResult;
         protected FeatureDetectionResult _mvcFeatureDetectionResult;
         protected FeatureDetectionResult _webApiFeatureDetectionResult;
         protected FeatureDetectionResult _webClassLibraryFeatureDetectionResult;
 
+        protected string CoreMvcProjectName => "CoreMVC";
+        protected string CoreWebApiProjectName => "CoreWebApi";
         protected string Ef6ProjectName => "EF6_Test";
         protected string MvcProjectName => "ASP.NET-MVC-Framework";
         protected string WebApiProjectName => "WebApi-Framework";
@@ -33,6 +37,8 @@ namespace CTA.FeatureDetection.Tests.TestBase
         {
             TestProjectDirectory = TestUtils.GetTestAssemblySourceDirectory(typeof(TestUtils));
             FeatureDetector = TestProjectsSetupFixture.FeatureDetector;
+            _coreMvcFeatureDetectionResult = TestProjectsSetupFixture.CoreMvcFeatureDetectionResult;
+            _coreWebApiFeatureDetectionResult = TestProjectsSetupFixture.CoreWebApiFeatureDetectionResult;
             _ef6FeatureDetectionResult = TestProjectsSetupFixture.Ef6FeatureDetectionResult;
             _mvcFeatureDetectionResult = TestProjectsSetupFixture.MvcFeatureDetectionResult;
             _webApiFeatureDetectionResult = TestProjectsSetupFixture.WebApiFeatureDetectionResult;

--- a/tst/CTA.FeatureDetection.Tests/Utils/AnalyzerResultsFactory.cs
+++ b/tst/CTA.FeatureDetection.Tests/Utils/AnalyzerResultsFactory.cs
@@ -51,7 +51,8 @@ namespace CTA.FeatureDetection.Tests.Utils
                     DeclarationNodes = true,
                     LocationData = true,
                     ReferenceData = true,
-                    LoadBuildData = true
+                    LoadBuildData = true,
+                    ReturnStatements = true
                 }
             };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* add project type feature for ASP.NET Core MVC projects
* add project type feature for ASP.NET Core WebApi projects
* Notes RE: how these features are detected
  * MVC conditions: 
     1. At least 1 controller derived from `Controller`<sup>1</sup> abstract class that also returns a View object<sup>2</sup>
     2. AND `Views` folder exists and is not empty
  * WebApi conditions: 
    1. At least 1 controller derived from `ControllerBase`<sup>1</sup> with zero controllers derived from `Controller` abstract class
    2. OR all controllers derived from `Controller` abstract class do not return any View objects

<sup>1</sup> ASP.NET Core merged MVC and WebApi libraries in the same MVC library so we need to be more mindful of how the libraries are use rather than looking for package references like we did for ASP.NET project types. The `ControllerBase` abstract class is generally used for WebApi projects as they do not have any methods that return View objects. The `Controller` abstract class is generally used for MVC controllers and allows for returning View objects, but they don't always have to return views. Core WebApi projects that do not follow best practices might use a controller derived from the `Controller` abstract class so we want to account for those cases.

<sup>2</sup> "View objects" in this context are any instances from a class that implements `IActionResult` and also returns a View or a Partial View (i.e. `PartialViewResult`, `ViewResult`, or `ViewComponentResult`). These classes were determined from the [list of classes derived from the IActionResult interface](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.iactionresult?view=aspnetcore-3.1)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
