### PR TITLE
owin unit tests

### DIFF
--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -30,18 +30,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestAspNetRoutes5Solution()
+        public void TestAspNetRoutes5Solution()
         {
-            await TestAspNetRoutes("net5.0");
+            TestAspNetRoutes("net5.0");
         }
 
         [Test]
-        public async Task TestAspNetRoutes3Solution()
+        public void TestAspNetRoutes3Solution()
         {
-            await TestAspNetRoutes("netcoreapp3.1");
+            TestAspNetRoutes("netcoreapp3.1");
         }
 
-        private async Task TestAspNetRoutes(string version)
+        private void TestAspNetRoutes(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("AspNetRoutes.sln", tempDir, downloadLocation, version);
 
@@ -81,18 +81,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestBranchingPipelines5Solution()
+        public void TestBranchingPipelines5Solution()
         {
-            await TestBranchingPipelines("net5.0");
+            TestBranchingPipelines("net5.0");
         }
 
         [Test]
-        public async Task TestBranchingPipelines3Solution()
+        public void TestBranchingPipelines3Solution()
         {
-            await TestBranchingPipelines("netcoreapp3.1");
+            TestBranchingPipelines("netcoreapp3.1");
         }
 
-        private async Task TestBranchingPipelines(string version)
+        private void TestBranchingPipelines(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("BranchingPipelines.sln", tempDir, downloadLocation, version);
 
@@ -127,18 +127,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestEmbedded5Solution()
+        public void TestEmbedded5Solution()
         {
-            await TestEmbedded("net5.0");
+            TestEmbedded("net5.0");
         }
 
         [Test]
-        public async Task TestEmbedded3Solution()
+        public void TestEmbedded3Solution()
         {
-            await TestEmbedded("netcoreapp3.1");
+            TestEmbedded("netcoreapp3.1");
         }
 
-        private async Task TestEmbedded(string version)
+        private void TestEmbedded(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("Embedded.sln", tempDir, downloadLocation, version);
 
@@ -164,18 +164,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestCustomServer5Solution()
+        public void TestCustomServer5Solution()
         {
-            await TestCustomServer("net5.0");
+            TestCustomServer("net5.0");
         }
 
         [Test]
-        public async Task TestCustomServer3Solution()
+        public void TestCustomServer3Solution()
         {
-            await TestCustomServer("netcoreapp3.1");
+            TestCustomServer("netcoreapp3.1");
         }
 
-        private async Task TestCustomServer(string version)
+        private void TestCustomServer(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("CustomServer.sln", tempDir, downloadLocation, version);
 
@@ -209,18 +209,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestHelloWorld5Solution()
+        public void TestHelloWorld5Solution()
         {
-            await TestHelloWorld("net5.0");
+            TestHelloWorld("net5.0");
         }
 
         [Test]
-        public async Task TestHelloWorld3Solution()
+        public void TestHelloWorld3Solution()
         {
-            await TestHelloWorld("netcoreapp3.1");
+            TestHelloWorld("netcoreapp3.1");
         }
 
-        private async Task TestHelloWorld(string version)
+        private void TestHelloWorld(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("HelloWorld.sln", tempDir, downloadLocation, version);
 
@@ -240,18 +240,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestHelloWorldRawOwin5Solution()
+        public void TestHelloWorldRawOwin5Solution()
         {
-            await TestHelloWorldRawOwin("net5.0");
+            TestHelloWorldRawOwin("net5.0");
         }
 
         [Test]
-        public async Task TestHelloWorldRawOwin3Solution()
+        public void TestHelloWorldRawOwin3Solution()
         {
-            await TestHelloWorldRawOwin("netcoreapp3.1");
+            TestHelloWorldRawOwin("netcoreapp3.1");
         }
 
-        private async Task TestHelloWorldRawOwin(string version)
+        private void TestHelloWorldRawOwin(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("HelloWorldRawOwin.sln", tempDir, downloadLocation, version);
 
@@ -264,18 +264,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestOwinSelfHostSample5Solution()
+        public void TestOwinSelfHostSample5Solution()
         {
-            await TestOwinSelfHostSample("net5.0");
+            TestOwinSelfHostSample("net5.0");
         }
 
         [Test]
-        public async Task TestOwinSelfHostSample3Solution()
+        public void TestOwinSelfHostSample3Solution()
         {
-            await TestOwinSelfHostSample("netcoreapp3.1");
+            TestOwinSelfHostSample("netcoreapp3.1");
         }
 
-        private async Task TestOwinSelfHostSample(string version)
+        private void TestOwinSelfHostSample(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("OwinSelfhostSample.sln", tempDir, downloadLocation, version);
 
@@ -294,18 +294,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestSignalR5Solution()
+        public void TestSignalR5Solution()
         {
-            await TestSignalR("net5.0");
+            TestSignalR("net5.0");
         }
 
         [Test]
-        public async Task TestSignalR3Solution()
+        public void TestSignalR3Solution()
         {
-            await TestSignalR("netcoreapp3.1");
+            TestSignalR("netcoreapp3.1");
         }
 
-        private async Task TestSignalR(string version)
+        private void TestSignalR(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("SignalR.sln", tempDir, downloadLocation, version);
 
@@ -324,18 +324,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestStaticFilesSample5Solution()
+        public void TestStaticFilesSample5Solution()
         {
-            await TestStaticFilesSample("net5.0");
+            TestStaticFilesSample("net5.0");
         }
 
         [Test]
-        public async Task TestStaticFilesSample3Solution()
+        public void TestStaticFilesSample3Solution()
         {
-            await TestStaticFilesSample("netcoreapp3.1");
+            TestStaticFilesSample("netcoreapp3.1");
         }
 
-        private async Task TestStaticFilesSample(string version)
+        private void TestStaticFilesSample(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("StaticFilesSample.sln", tempDir, downloadLocation, version);
 
@@ -357,18 +357,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestWebApi5Solution()
+        public void TestWebApi5Solution()
         {
-            await TestWebApi("net5.0");
+            TestWebApi("net5.0");
         }
 
         [Test]
-        public async Task TestWebApi3Solution()
+        public void TestWebApi3Solution()
         {
-            await TestWebApi("netcoreapp3.1");
+            TestWebApi("netcoreapp3.1");
         }
 
-        private async Task TestWebApi(string version)
+        private void TestWebApi(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("OwinWebApi.sln", tempDir, downloadLocation, version);
 
@@ -383,18 +383,18 @@ namespace CTA.Rules.Test
         }
 
         [Test]
-        public async Task TestWebSocketSample5Solution()
+        public void TestWebSocketSample5Solution()
         {
-            await TestWebSocketSample("net5.0");
+            TestWebSocketSample("net5.0");
         }
 
         [Test]
-        public async Task TestWebSocketSample3Solution()
+        public void TestWebSocketSample3Solution()
         {
-            await TestWebSocketSample("netcoreapp3.1");
+            TestWebSocketSample("netcoreapp3.1");
         }
 
-        private async Task TestWebSocketSample(string version)
+        private void TestWebSocketSample(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("WebSocketSample.sln", tempDir, downloadLocation, version);
 

--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -1,0 +1,424 @@
+﻿using Codelyzer.Analysis;
+using CTA.Rules.Config;
+using CTA.Rules.Test;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CTA.Rules.Test
+{
+    public class OwinTests : AwsRulesBaseTest
+    {
+        public string tempDir = "";
+        public string downloadLocation;
+
+        [SetUp]
+        public void Setup()
+        {
+            Setup(this.GetType());
+            tempDir = GetTstPath(Path.Combine(new string[] { "Projects", "Temp" }));
+            DownloadTestProjects();
+        }
+
+        private void DownloadTestProjects()
+        {
+            downloadLocation = DownloadTestProjects(tempDir);
+        }
+
+        [Test]
+        public async Task TestAspNetRoutes5Solution()
+        {
+            await TestAspNetRoutes("net5.0");
+        }
+
+        [Test]
+        public async Task TestAspNetRoutes3Solution()
+        {
+            await TestAspNetRoutes("netcoreapp3.1");
+        }
+
+        private async Task TestAspNetRoutes(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("AspNetRoutes.sln", tempDir, downloadLocation, version);
+
+            var analysisResult = results.SolutionAnalysisResult;
+            var csProjContent = results.ProjectResults.FirstOrDefault().CsProjectContent;
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+
+            StringAssert.Contains("Microsoft.AspNetCore.Owin", analysisResult);
+            StringAssert.Contains("Replace IOwinContext with HttpContext", analysisResult);
+
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+            //var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
+            var owinapp2Text = File.ReadAllText(Path.Combine(projectDir, "OwinApp2.cs"));
+
+            //Check that namespace was added
+            StringAssert.Contains(@"using Microsoft.AspNetCore.Http", owinapp2Text);
+
+            //Check that httpcontext is added (with a space) to make sure it's not httpcontextbase
+            StringAssert.Contains(@"HttpContext ", owinapp2Text);
+
+            //Check that namespaces were added
+            //StringAssert.Contains(@"Microsoft.AspNetCore.Hosting", programText);
+            //StringAssert.Contains(@"Microsoft.Extensions.Hosting;", programText);
+
+            //Check that namespace was added
+            StringAssert.Contains(@"Microsoft.AspNetCore.Http", startupText);
+
+            //Check that httpcontext is added (with a space) to make sure it's not httpcontextbase
+            StringAssert.Contains(@"HttpContext ", startupText);
+
+            //Check that files have been created
+            FileAssert.Exists(Path.Combine(projectDir, "Startup.cs"));
+            //FileAssert.Exists(Path.Combine(projectDir, "Program.cs")); // This should be added but class library does not do this
+
+            //Check that package has been added:
+            //Assert.True(csProjContent.IndexOf(@"Microsoft.AspNetCore.Owin") > 0);
+        }
+
+        [Test]
+        public async Task TestBranchingPipelines5Solution()
+        {
+            await TestBranchingPipelines("net5.0");
+        }
+
+        [Test]
+        public async Task TestBranchingPipelines3Solution()
+        {
+            await TestBranchingPipelines("netcoreapp3.1");
+        }
+
+        private async Task TestBranchingPipelines(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("BranchingPipelines.sln", tempDir, downloadLocation, version);
+
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+            //var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
+            var displayText = File.ReadAllText(Path.Combine(projectDir, "DisplayBreadCrumbs.cs"));
+            var addText = File.ReadAllText(Path.Combine(projectDir, "AddBreadCrumbMiddleware.cs"));
+
+            StringAssert.Contains(@"using Microsoft.AspNetCore.Http", displayText);
+            StringAssert.Contains(@"HttpContext ", displayText);
+            StringAssert.Contains(@"RequestDelegate ", displayText);
+            StringAssert.Contains(@"TryGetValue", displayText);
+            StringAssert.Contains(@"remove the base class here : OwinMiddleware", displayText);
+            //StringAssert.DoesNotContain(@"base(next)", displayText);
+            //StringAssert.DoesNotContain(@"override", displayText);
+
+            StringAssert.Contains(@"using Microsoft.AspNetCore.Http", addText);
+            StringAssert.Contains(@"HttpContext ", addText);
+            StringAssert.Contains(@"RequestDelegate ", addText);
+            StringAssert.Contains(@"_next", addText);
+            StringAssert.Contains(@"remove the base class here : OwinMiddleware", addText);
+            //StringAssert.DoesNotContain(@"base(next)", addText);
+            //StringAssert.DoesNotContain(@"override", addText);
+
+            StringAssert.Contains(@"using Microsoft.AspNetCore.Http", startupText);
+            StringAssert.Contains(@"HttpContext ", startupText);
+            StringAssert.Contains(@"UseMiddleware", startupText);
+
+            //FileAssert.Exists(Path.Combine(projectDir, "Program.cs")); // This should be added but class library does not do this
+        }
+
+        [Test]
+        public async Task TestEmbedded5Solution()
+        {
+            await TestEmbedded("net5.0");
+        }
+
+        [Test]
+        public async Task TestEmbedded3Solution()
+        {
+            await TestEmbedded("netcoreapp3.1");
+        }
+
+        private async Task TestEmbedded(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("Embedded.sln", tempDir, downloadLocation, version);
+
+            var analysisResult = results.SolutionAnalysisResult;
+
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+
+            StringAssert.Contains("Microsoft.AspNetCore.Owin", analysisResult);
+            StringAssert.Contains("Microsoft.AspNetCore.Hosting", analysisResult);
+            StringAssert.Contains("Microsoft.AspNetCore.Server.Kestrel", analysisResult);
+
+            //Host program.cs rule and dependencies
+
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+            var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
+
+            StringAssert.Contains(@"Microsoft.AspNetCore.Builder", startupText);
+            StringAssert.Contains(@"IApplicationBuilder", startupText);
+
+            StringAssert.Contains("Microsoft.AspNetCore.Hosting", programText);
+            StringAssert.Contains("Microsoft.AspNetCore.Server.Kestrel", programText);
+            StringAssert.Contains("WebHostBuilder", programText);
+        }
+
+        [Test]
+        public async Task TestCustomServer5Solution()
+        {
+            await TestCustomServer("net5.0");
+        }
+
+        [Test]
+        public async Task TestCustomServer3Solution()
+        {
+            await TestCustomServer("netcoreapp3.1");
+        }
+
+        private async Task TestCustomServer(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("CustomServer.sln", tempDir, downloadLocation, version);
+
+            var myApp = results.ProjectResults.Where(p => p.CsProjectPath.EndsWith("MyApp.csproj")).FirstOrDefault();
+            FileAssert.Exists(myApp.CsProjectPath);
+            var customServer = results.ProjectResults.Where(p => p.CsProjectPath.EndsWith("MyCustomServer.csproj")).FirstOrDefault();
+            FileAssert.Exists(customServer.CsProjectPath);
+
+            StringAssert.Contains("Microsoft.AspNetCore.Owin", results.SolutionAnalysisResult);
+            StringAssert.Contains("Microsoft.AspNetCore.Hosting", results.SolutionAnalysisResult);
+            StringAssert.Contains("Microsoft.AspNetCore.Server.Kestrel", results.SolutionAnalysisResult);
+
+            //MyApp
+            var startupText = File.ReadAllText(Path.Combine(myApp.ProjectDirectory, "Startup.cs"));
+            var programText = File.ReadAllText(Path.Combine(myApp.ProjectDirectory, "Program.cs"));
+
+            StringAssert.Contains(@"Microsoft.AspNetCore.Builder", startupText);
+            StringAssert.Contains(@"IApplicationBuilder", startupText);
+
+            StringAssert.Contains("WebHostBuilder", programText);
+
+            //Check for comment on how to implement a custom server here in program
+
+            //CustomServer
+            var customerServerText = File.ReadAllText(Path.Combine(customServer.ProjectDirectory, "CustomServer.cs"));
+            var serverFactoryText = File.ReadAllText(Path.Combine(customServer.ProjectDirectory, "ServerFactory.cs"));
+
+            //MyCustomerServer very difficult
+            //Keep their server intact but must implement IServer instead of just IDisposable
+            //Change their Start class to implement StartAsync instead and change reference to it to startAsync also
+        }
+
+        [Test]
+        public async Task TestHelloWorld5Solution()
+        {
+            await TestHelloWorld("net5.0");
+        }
+
+        [Test]
+        public async Task TestHelloWorld3Solution()
+        {
+            await TestHelloWorld("netcoreapp3.1");
+        }
+
+        private async Task TestHelloWorld(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("HelloWorld.sln", tempDir, downloadLocation, version);
+
+            var analysisResult = results.SolutionAnalysisResult;
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+
+            StringAssert.Contains("Microsoft.AspNetCore.Owin", analysisResult);
+            StringAssert.Contains("Replace IOwinContext with HttpContext", analysisResult);
+
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+
+            //Check that namespace was added
+            StringAssert.Contains(@"Microsoft.AspNetCore.Http", startupText);
+
+            //Check that httpcontext is added (with a space) to make sure it's not httpcontextbase
+            StringAssert.Contains(@"HttpContext ", startupText);
+        }
+
+        [Test]
+        public async Task TestHelloWorldRawOwin5Solution()
+        {
+            await TestHelloWorldRawOwin("net5.0");
+        }
+
+        [Test]
+        public async Task TestHelloWorldRawOwin3Solution()
+        {
+            await TestHelloWorldRawOwin("netcoreapp3.1");
+        }
+
+        private async Task TestHelloWorldRawOwin(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("HelloWorldRawOwin.sln", tempDir, downloadLocation, version);
+
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+
+            StringAssert.Contains(@"Microsoft.AspNetCore.Builder", startupText);
+            StringAssert.Contains(@"IApplicationBuilder", startupText);
+            StringAssert.Contains(@"UseOwin", startupText);
+        }
+
+        [Test]
+        public async Task TestOwinSelfHostSample5Solution()
+        {
+            await TestOwinSelfHostSample("net5.0");
+        }
+
+        [Test]
+        public async Task TestOwinSelfHostSample3Solution()
+        {
+            await TestOwinSelfHostSample("netcoreapp3.1");
+        }
+
+        private async Task TestOwinSelfHostSample(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("OwinSelfhostSample.sln", tempDir, downloadLocation, version);
+
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+            var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
+
+            StringAssert.Contains(@"UseEndpoints", startupText);
+            StringAssert.Contains(@"ConfigureServices", startupText);
+            StringAssert.Contains(@"MapControllers", startupText);
+            StringAssert.Contains(@"Microsoft.AspNetCore.Builder", startupText);
+            StringAssert.Contains(@"Microsoft.Extensions.DependencyInjection", startupText);
+            StringAssert.DoesNotContain(@"System.Web.Http", startupText);
+
+            StringAssert.Contains("WebHostBuilder", programText);
+        }
+
+        [Test]
+        public async Task TestSignalR5Solution()
+        {
+            await TestSignalR("net5.0");
+        }
+
+        [Test]
+        public async Task TestSignalR3Solution()
+        {
+            await TestSignalR("netcoreapp3.1");
+        }
+
+        private async Task TestSignalR(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("SignalR.sln", tempDir, downloadLocation, version);
+
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+            var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
+
+            StringAssert.Contains(@"UseSignalR", startupText);
+            StringAssert.Contains(@"ConfigureServices", startupText);
+            StringAssert.Contains(@"AddSignalR", startupText);
+            StringAssert.Contains(@"MapHub", startupText);
+            StringAssert.Contains(@"Microsoft.AspNetCore.Builder", startupText);
+            StringAssert.Contains(@"Microsoft.Extensions.DependencyInjection", startupText);
+
+            StringAssert.Contains("WebHostBuilder", programText);
+        }
+
+        [Test]
+        public async Task TestStaticFilesSample5Solution()
+        {
+            await TestStaticFilesSample("net5.0");
+        }
+
+        [Test]
+        public async Task TestStaticFilesSample3Solution()
+        {
+            await TestStaticFilesSample("netcoreapp3.1");
+        }
+
+        private async Task TestStaticFilesSample(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("StaticFilesSample.sln", tempDir, downloadLocation, version);
+
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+            var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
+
+            StringAssert.Contains(@"UseDeveloperExceptionPage", startupText);
+            StringAssert.Contains(@"AddDirectoryBrowser", startupText);
+            StringAssert.Contains(@"FileProvider", startupText);
+            StringAssert.Contains(@"Microsoft.AspNetCore.Builder", startupText);
+            StringAssert.Contains(@"Microsoft.Extensions.DependencyInjection", startupText);
+            StringAssert.Contains(@"Microsoft.Extensions.FileProviders", startupText);
+            StringAssert.Contains(@"Microsoft.AspNetCore.StaticFiles", startupText);
+            StringAssert.DoesNotContain(@"Microsoft.Owin.StaticFiles", startupText);
+            StringAssert.DoesNotContain(@"Microsoft.Owin.FileSystems", startupText);
+
+            StringAssert.Contains("WebHostBuilder", programText);
+        }
+
+        [Test]
+        public async Task TestWebApi5Solution()
+        {
+            await TestWebApi("net5.0");
+        }
+
+        [Test]
+        public async Task TestWebApi3Solution()
+        {
+            await TestWebApi("netcoreapp3.1");
+        }
+
+        private async Task TestWebApi(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("OwinWebApi.sln", tempDir, downloadLocation, version);
+
+            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+            var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
+
+            StringAssert.Contains(@"UseEndpoints", startupText);
+            StringAssert.Contains(@"ConfigureServices", startupText);
+            StringAssert.Contains(@"MapControllers", startupText);
+            StringAssert.Contains(@"Microsoft.AspNetCore.Builder", startupText);
+            StringAssert.Contains(@"Microsoft.Extensions.DependencyInjection", startupText);
+        }
+
+        [Test]
+        public async Task TestWebSocketSample5Solution()
+        {
+            await TestWebSocketSample("net5.0");
+        }
+
+        [Test]
+        public async Task TestWebSocketSample3Solution()
+        {
+            await TestWebSocketSample("netcoreapp3.1");
+        }
+
+        private async Task TestWebSocketSample(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("WebSocketSample.sln", tempDir, downloadLocation, version);
+
+            var sampleClient = results.ProjectResults.Where(p => p.CsProjectPath.EndsWith("SampleClient.csproj")).FirstOrDefault();
+            FileAssert.Exists(sampleClient.CsProjectPath);
+            var webSocketServer = results.ProjectResults.Where(p => p.CsProjectPath.EndsWith("WebSocketServer.csproj")).FirstOrDefault();
+            FileAssert.Exists(webSocketServer.CsProjectPath);
+
+            var clientProgramText = File.ReadAllText(Path.Combine(sampleClient.ProjectDirectory, "Program.cs"));
+
+            var serverStartupText = File.ReadAllText(Path.Combine(webSocketServer.ProjectDirectory, "Startup.cs"));
+            var serverProgramText = File.ReadAllText(Path.Combine(webSocketServer.ProjectDirectory, "Program.cs"));
+
+            StringAssert.Contains(@"Microsoft.AspNetCore.Builder", serverStartupText);
+            StringAssert.Contains(@"IApplicationBuilder", serverStartupText);
+            StringAssert.Contains(@"UseOwin", serverStartupText);
+
+            StringAssert.Contains("WebHostBuilder", serverProgramText);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            Directory.Delete(GetTstPath(Path.Combine(new string[] { "Projects", "Temp" })), true);
+        }
+    }
+}


### PR DESCRIPTION

Notes

Provide any additional information about your changes

Contains all the unit tests for the Owin rules. All pass successfully locally.

These unit tests cover all 3 owin rule files, Owin.json, Microsoft.Owin and Microsoft.Owin.Hosting.
Testing

Describe how these changes were tested.

All rules were successful while pointing locally at the Owin rules folder. This PR should NOT be merged until I can also test these while pulling directly from the S3 bucket of rules.

