### PR TITLE
add unit tests for Ionic.Zip porting rules

### DIFF
--- a/tst/CTA.Rules.Test/PortCoreTests.cs
+++ b/tst/CTA.Rules.Test/PortCoreTests.cs
@@ -298,6 +298,28 @@ namespace CTA.Rules.Test
             StringAssert.Contains("Include=\"Antlr3.Runtime\"", csProjectContent);
         }
 
+        [Test]
+        public void TestIonicZipSample3()
+        {
+            TestIonicZipSampleSolution("netcoreapp3.1");
+        }
+
+        private void TestIonicZipSampleSolution(string version)
+        {
+            TestSolutionAnalysis results = AnalyzeSolution("IonicZipSample.sln", tempDir, downloadLocation, version);
+
+            // Verify new .csproj file exists
+            var ionicZipProjectFile = results.ProjectResults.Where(p => p.CsProjectPath.EndsWith("IonicZipSample.csproj")).FirstOrDefault();
+            FileAssert.Exists(ionicZipProjectFile.CsProjectPath);
+
+            // No build errors expected in the ported project
+            Assert.False(results.SolutionRunResult.BuildErrors[ionicZipProjectFile.CsProjectPath].Any());
+
+            // Verify the new package has been added
+            var csProjectContent = ionicZipProjectFile.CsProjectContent;
+            StringAssert.Contains("Include=\"DotNetZip\"", csProjectContent);
+        }
+
         [TearDown]
         public void Cleanup()
         {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/cta/issues/37

*Description of changes:*
* add unit tests for rules added in this [PR](https://github.com/aws/porting-assistant-dotnet-datastore/pull/31)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
