### PR TITLE
Issue 51: Refactor ProjectFileCreator class

### DIFF
--- a/src/CTA.Rules.ProjectFile/ProjectFileCreator.cs
+++ b/src/CTA.Rules.ProjectFile/ProjectFileCreator.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using CTA.Rules.Config;
 using CTA.Rules.Models;
@@ -12,39 +11,49 @@ namespace CTA.Rules.ProjectFile
     public class ProjectFileCreator
     {
         private string _projectFile;
-
         private List<string> _targetVersions;
         private Dictionary<string, string> _packages;
         private IEnumerable<string> _projectReferences;
         private ProjectType _projectType;
 
+        private const string CsCoreProjSyntaxWeb = 
+@"<Project Sdk=""{0}"">
+  <PropertyGroup>
+    <TargetFramework>{1}</TargetFramework>
+  </PropertyGroup>
+{2}
+{3}
+</Project>";
 
-        public const string csCoreProjSyntaxWeb = @"
-                <Project Sdk=""{0}"">
-                    <PropertyGroup>
-                        <TargetFramework>{1}</TargetFramework>
-                    </PropertyGroup>
-                    {2}
-                </Project>";
+        private const string CsCoreProjSyntaxWebClassLibrary =
+@"<Project Sdk=""{0}"">
+  <PropertyGroup>
+    <TargetFramework>{1}</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include=""Microsoft.AspNetCore.App"" />
+  </ItemGroup>
+{2}
+{3}
+</Project>";
 
-        public const string csCoreProjSyntaxWebClassLibrary = @"
-                <Project Sdk=""{0}"">
-                    <PropertyGroup>
-                        <TargetFramework>{1}</TargetFramework>
-                    </PropertyGroup>
-                    <ItemGroup>
-                        <FrameworkReference Include=""Microsoft.AspNetCore.App"" />
-                    </ItemGroup>
-                    {2}
-                </Project>";
+        private const string CsCoreProjSyntaxClassLibrary =
+@"<Project Sdk=""{0}"">
+  <PropertyGroup>
+    <TargetFramework>{1}</TargetFramework>
+  </PropertyGroup>
+{2}
+{3}
+</Project>";
 
-        public const string csCoreProjSyntaxClassLibrary = @"
-                <Project Sdk=""{0}"">
-                    <PropertyGroup>
-                        <TargetFramework>{1}</TargetFramework>
-                    </PropertyGroup>
-                    {2}
-                </Project>";
+        private const string ItemGroupTemplate =
+@"<ItemGroup>
+{0}
+</ItemGroup>";
+
+        private const string PackageReferenceTemplate = @"<PackageReference Include=""{0}"" Version=""{1}"" />";
+        private const string ProjectReferenceTemplate = @"<ProjectReference Include=""{0}"" />";
+        private const string IndentationPerLevel = "  ";
 
         public ProjectFileCreator(string projectFile, List<string> targetVersions, Dictionary<string, string> packages,
             List<string> projectReferences, ProjectType projectType)
@@ -75,28 +84,27 @@ namespace CTA.Rules.ProjectFile
         /// <summary>
         /// Replaces the current project file with a new file 
         /// </summary>
-        /// <param name="projectFile">Current project file</param>
         public bool Create()
         {
             try
             {
                 string sdkName = Constants.ClassLibrarySdkName;
-                string csProj = csCoreProjSyntaxClassLibrary;
+                string csProj = CsCoreProjSyntaxClassLibrary;
 
                 if (_projectType == ProjectType.Mvc || _projectType == ProjectType.WebApi)
                 {
-                    csProj = csCoreProjSyntaxWeb;
+                    csProj = CsCoreProjSyntaxWeb;
                     sdkName = Constants.WebSdkName;
                 }
                 else if (_projectType == ProjectType.WebClassLibrary)
                 {
-                    csProj = csCoreProjSyntaxWebClassLibrary;
+                    csProj = CsCoreProjSyntaxWebClassLibrary;
                 }
 
                 string packages = GetPackagesSection();
                 string projects = GetProjectReferencesSection();
 
-                string csProjContent = string.Format(csProj, sdkName, GetTargetVersions(), string.Concat(AddItemGroup(packages), AddItemGroup(projects)));
+                string csProjContent = string.Format(csProj, sdkName, GetTargetVersions(), AddItemGroup(packages), AddItemGroup(projects));
                 File.WriteAllText(_projectFile, csProjContent);
             }
             catch (Exception ex)
@@ -109,45 +117,51 @@ namespace CTA.Rules.ProjectFile
 
         private string AddItemGroup(string content)
         {
-            if (!string.IsNullOrEmpty(content))
+            if (string.IsNullOrEmpty(content))
             {
-                return string.Format(@"
-                <ItemGroup>
-                    {0}
-                </ItemGroup>", content);
+                return string.Empty;
             }
-            return string.Empty;
+            
+            var itemGroupContent = string.Format(ItemGroupTemplate, content);
+            itemGroupContent = IndentAllLines(itemGroupContent);
+
+            return itemGroupContent;
         }
 
         private string GetPackagesSection()
         {
-            string packageSyntax = @"<PackageReference Include=""{0}"" Version=""{1}"" />";
-            StringBuilder str = new StringBuilder();
-            foreach (var action in _packages)
+            IEnumerable<string> packages = new List<string>();
+            packages = _packages.Select(package =>
             {
-                str.Append(string.Format(packageSyntax, action.Key, action.Value)).Append(Environment.NewLine);
-            }
-            if (_packages.Count() > 0)
+                var packageName = package.Key;
+                var packageVersion = package.Value;
+
+                return string.Format(PackageReferenceTemplate, packageName, packageVersion);
+            });
+
+            if (_packages.Any())
             {
                 LogChange(string.Format("Adding reference to packages {0}", string.Join(",", _packages.Select(p => p.Key))));
             }
-            return str.ToString();
+            
+            var content = string.Join(Environment.NewLine, packages);
+            content = IndentAllLines(content);
+            return content;
         }
 
         private string GetProjectReferencesSection()
         {
-            List<string> references = new List<string>();
-            string projectReferenceTemplate = @"<ProjectReference Include=""{0}"" />";
-
+            IEnumerable<string> references = new List<string>();
             if (_projectReferences != null)
             {
-                foreach (var projectReference in _projectReferences)
-                {
-                    references.Add(string.Format(projectReferenceTemplate, projectReference));
-                }
+                references = _projectReferences.Select(projectReference => 
+                    string.Format(ProjectReferenceTemplate, projectReference));
             }
 
-            return string.Join(Environment.NewLine, references);
+            var content = string.Join(Environment.NewLine, references);
+            content = IndentAllLines(content);
+
+            return content;
         }
 
         private void LogChange(string message)
@@ -158,7 +172,6 @@ namespace CTA.Rules.ProjectFile
         private void PopulateFromExistingFile()
         {
             var xDocument = XDocument.Load(_projectFile);
-            var packages = new Dictionary<string, string>();
 
             try
             {
@@ -178,7 +191,7 @@ namespace CTA.Rules.ProjectFile
 
             try
             {
-                packages = xDocument.Descendants()
+                var packages = xDocument.Descendants()
                     .Where(d => d.Name == "PackageReference")
                     .ToDictionary(p => p.Attributes("Include").First().Value, p => p.Attributes("Version").First().Value);
 
@@ -188,11 +201,10 @@ namespace CTA.Rules.ProjectFile
             {
                 //If we're using a framework csproj, we will get an error. No need to catch since we're overwriting the csproj file
             }
-            var projects = new List<string>();
 
             try
             {
-                projects = xDocument.Descendants()
+                var projects = xDocument.Descendants()
                     .Where(d => d.Name == "ProjectReference")
                     .Select(p => p.Attributes("Include").First().Value).ToList();
 
@@ -216,6 +228,12 @@ namespace CTA.Rules.ProjectFile
             }
         }
 
+        private static string IndentAllLines(string content)
+        {
+            var lines = content.Split(Environment.NewLine);
+            var indentedLines = lines.Select(line => $"{IndentationPerLevel}{line}");
 
+            return string.Join(Environment.NewLine, indentedLines);
+        }
     }
 }

--- a/tst/CTA.Rules.Test/ProjectFileCreatorTests.cs
+++ b/tst/CTA.Rules.Test/ProjectFileCreatorTests.cs
@@ -1,0 +1,135 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using CTA.Rules.Models;
+using CTA.Rules.ProjectFile;
+using NUnit.Framework;
+
+namespace CTA.Rules.Test
+{
+    public class ProjectFileCreatorTests
+    {
+        private ProjectFileCreator _mvcProjectFileCreator;
+        private ProjectFileCreator _classLibraryProjectFileCreator;
+        private ProjectFileCreator _webClassLibraryProjectFileCreator;
+
+        private string _mvcProjectFilePath = "mvc.csproj";
+        private string _classLibraryProjectFilePath = "classLibrary.csproj";
+        private string _webClassLibraryProjectFilePath = "webClassLibrary.csproj";
+
+        [SetUp]
+        public void Setup()
+        {
+            CreateEmptyXmlDocument(_mvcProjectFilePath);
+            CreateEmptyXmlDocument(_classLibraryProjectFilePath);
+            CreateEmptyXmlDocument(_webClassLibraryProjectFilePath);
+
+            var targetFramework = new List<string> { "netcoreapp3.1" };
+            var packages = new Dictionary<string, string>
+            {
+                { "MyFirstPackage", "1.0.0" },
+                { "MySecondPackage", "2.0.0" }
+            };
+            var projectReferences = new List<string>
+            {
+                "TheMainProject",
+                "TheDependency"
+            };
+
+            _mvcProjectFileCreator = new ProjectFileCreator(_mvcProjectFilePath, targetFramework, 
+                packages, projectReferences, ProjectType.Mvc);
+            _classLibraryProjectFileCreator = new ProjectFileCreator(_classLibraryProjectFilePath, targetFramework, 
+                packages, projectReferences, ProjectType.ClassLibrary);
+            _webClassLibraryProjectFileCreator = new ProjectFileCreator(_webClassLibraryProjectFilePath, targetFramework, 
+                packages, projectReferences, ProjectType.WebClassLibrary);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(_webClassLibraryProjectFilePath))
+            {
+                File.Delete(_webClassLibraryProjectFilePath);
+            }
+        }
+
+        [Test]
+        public void Create_Produces_Formatted_Mvc_Project_File()
+        {
+            _mvcProjectFileCreator.Create();
+            var projectFileContents = File.ReadAllText(_mvcProjectFilePath);
+
+            var expectedProjectFileContents =
+@"<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""MyFirstPackage"" Version=""1.0.0"" />
+    <PackageReference Include=""MySecondPackage"" Version=""2.0.0"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""TheMainProject"" />
+    <ProjectReference Include=""TheDependency"" />
+  </ItemGroup>
+</Project>";
+
+            Assert.AreEqual(expectedProjectFileContents, projectFileContents);
+        }
+
+        [Test]
+        public void Create_Produces_Formatted_ClassLibrary_Project_File()
+        {
+            _classLibraryProjectFileCreator.Create();
+            var projectFileContents = File.ReadAllText(_classLibraryProjectFilePath);
+
+            var expectedProjectFileContents =
+@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""MyFirstPackage"" Version=""1.0.0"" />
+    <PackageReference Include=""MySecondPackage"" Version=""2.0.0"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""TheMainProject"" />
+    <ProjectReference Include=""TheDependency"" />
+  </ItemGroup>
+</Project>";
+
+            Assert.AreEqual(expectedProjectFileContents, projectFileContents);
+        }
+
+        [Test]
+        public void Create_Produces_Formatted_WebClassLibrary_Project_File()
+        {
+            _webClassLibraryProjectFileCreator.Create();
+            var projectFileContents = File.ReadAllText(_webClassLibraryProjectFilePath);
+
+            var expectedProjectFileContents =
+@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include=""Microsoft.AspNetCore.App"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""MyFirstPackage"" Version=""1.0.0"" />
+    <PackageReference Include=""MySecondPackage"" Version=""2.0.0"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""TheMainProject"" />
+    <ProjectReference Include=""TheDependency"" />
+  </ItemGroup>
+</Project>";
+
+            Assert.AreEqual(expectedProjectFileContents, projectFileContents);
+        }
+        
+        private void CreateEmptyXmlDocument(string filePath)
+        {
+            File.WriteAllText(filePath, "<root></root>");
+        }
+    }
+}


### PR DESCRIPTION
## Related issue

Closes: #51


## Description
* Adjust spacing on template strings to match default convention set by Microsoft (2 spaces per indentation level)
* Assign `PackageReference` and `ProjectReference` sections to their own placeholders in the csproj template strings (originally, the two sections were concatenated and shared a single placeholder in the template)
* Move `ItemGroup`, `PackageReference`, and `ProjectReference` template strings to class-level variables
* Refactor `GetPackagesSection()` and `GetProjectReferencesSection()` methods to use the same convention
* Add unit tests to document the generated csproj file contents

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
