### PR TITLE
Overwrite s3 rules with temp bucket.

### DIFF
--- a/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
+++ b/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
@@ -149,10 +149,7 @@ namespace CTA.Rules.Test
             foreach(var file in files)
             {
                 string targetFile = Path.Combine(Constants.RulesDefaultPath, Path.GetFileName(file));
-                if (!File.Exists(targetFile))
-                {
                     File.Copy(file, targetFile);
-                }
             }
         }
 

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
@@ -1,0 +1,126 @@
+﻿{
+  "Name": "Microsoft.Owin.Hosting",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Owin",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Hosting",
+      "Value": "Microsoft.Owin.Hosting",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Hosting, Microsoft.AspNetCore.Server.Kestrel and remove Microsoft.Owin.Hosting and Owin.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Hosting",
+              "Description": "Add package Microsoft.AspNetCore.Hosting"
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Server.Kestrel",
+              "Description": "Add package Microsoft.AspNetCore.Server.Kestrel"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Hosting",
+              "Description": "Add Microsoft.AspNetCore.Hosting namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Hosting;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Server.Kestrel",
+              "Description": "Add Microsoft.AspNetCore.Server.Kestrel namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Server.Kestrel;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Hosting",
+              "Description": "Remove Microsoft.Owin.Hosting namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin.Hosting;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingOwin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Start",
+      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>",
+      "KeyType": "Name",
+      "ContainingType": "WebApp",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace WebApp.Start.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Microsoft.Owin.Hosting.WebApp.Start with WebHostBuilder such as: var host = new WebHostBuilder().UseKestrel().UseUrls(URL_HERE).UseStartup<Startup>().Build(); host.Start();",
+              "Description": "Add a comment to explain how to replace WebApp.Start.",
+              "ActionValidation": {
+                "Contains": "ReplaceMicrosoft.Owin.Hosting.WebApp.StartwithWebHostBuilder",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
@@ -1,0 +1,395 @@
+﻿{
+  "Name": "Microsoft.Owin",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Owin",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin",
+      "Value": "Microsoft.Owin",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Owin and remove Microsoft.Owin and Owin.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Owin",
+              "Description": "Add package Microsoft.AspNetCore.Owin"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Owin",
+              "Description": "Add Microsoft.AspNetCore.Owin namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Owin;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin",
+              "Description": "Remove Microsoft.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingOwin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IOwinContext",
+      "Value": "Microsoft.Owin.IOwinContext",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace IOwinContext with HttpContext and add Microsoft.AspNetCore.Http.HttpContext namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpContext",
+              "Description": "Replace IOwinContext with HttpContext",
+              "ActionValidation": {
+                "Contains": "HttpContext",
+                "NotContains": "IOwinContext"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "OwinMiddleware",
+      "Value": "Microsoft.Owin.OwinMiddleware",
+      "KeyType": "BaseClass",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Remove the base class for owin middleware, remove the override method modifier for the invoke method, add a new gloable xpression for RequestDelegate _next, initialize it in the constructor and remove the constructor intializer base(next).",
+          "Actions": [
+            {
+              "Name": "RemoveBaseClass",
+              "Type": "Class",
+              "Value": "OwinMiddleware",
+              "Description": "Remove the base class OwinMiddleware",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ":OwinMiddleware"
+              }
+            },
+            {
+              "Name": "ReplaceMethodModifiers",
+              "Type": "Class",
+              "Value": {
+                "methodName": "Invoke",
+                "modifiers": "public"
+              },
+              "Description": "Replace all the invoke method modifiers with only public in order to remove the override modifier.",
+              "ActionValidation": {
+                "Contains": "public",
+                "NotContains": "override"
+              }
+            },
+            {
+              "Name": "AddExpression",
+              "Type": "Class",
+              "Value": "RequestDelegate _next = null; //CTA Change",
+              "Description": "Add a new global variable to replace the OwinMiddleware global abstract variable of Next.",
+              "ActionValidation": {
+                "Contains": "RequestDelegate_next=null;//CTAChange",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AppendConstructorExpression",
+              "Type": "Class",
+              "Value": "_next = next;",
+              "Description": "Add a new expression in the constructor to initialize the new variable of _next to the next element in the pipeline.",
+              "ActionValidation": {
+                "Contains": "_next=next;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveConstructorInitializer",
+              "Type": "Class",
+              "Value": "next",
+              "Description": "Remove the base initializer for the constructor.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ":base(next)"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "OwinMiddleware",
+      "Value": "Microsoft.Owin.OwinMiddleware",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace OwinMiddleware with RequestDelegate and add Microsoft.AspNetCore.Http.RequestDelegate namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "RequestDelegate",
+              "Description": "Replace OwinMiddleware with RequestDelegate",
+              "ActionValidation": {
+                "Contains": "RequestDelegate",
+                "NotContains": "OwinMiddleware"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Namespace",
+      "Name": "StaticFiles",
+      "Value": "Microsoft.Owin.StaticFiles",
+      "KeyType": "Method",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.StaticFiles and Microsoft.Extensions.FileProviders.Physical packages. Add Microsoft.Extensions.FileProviders and Microsoft.AspNetCore.StaticFiles namespaces. Remove Microsoft.Owin.StaticFiles and Microsoft.Owin.FileSystems namespaces.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.StaticFiles",
+              "Description": "Add package Microsoft.AspNetCore.StaticFiles"
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.Extensions.FileProviders.Physical",
+              "Description": "Add package Microsoft.Extensions.FileProviders.Physical"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.FileProviders",
+              "Description": "Add Microsoft.Extensions.FileProviders",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.FileProviders;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.StaticFiles",
+              "Description": "Add Microsoft.AspNetCore.StaticFiles",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.StaticFiles;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.StaticFiles",
+              "Description": "Remove Microsoft.Owin.StaticFiles namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin.StaticFiles;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.FileSystems",
+              "Description": "Remove Microsoft.Owin.FileSystems namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin.FileSystems;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Invoke",
+      "Value": "Microsoft.Owin.OwinMiddleware.Invoke",
+      "KeyType": "Name",
+      "ContainingType": "OwinMiddleware",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "_next.Invoke",
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "_next.Invoke",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Get",
+      "Value": "Microsoft.Owin.IReadableStringCollection.Get(string)",
+      "KeyType": "Name",
+      "ContainingType": "IReadableStringCollection",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace the Get method with TryGetValue.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace Get with TryGetValue.",
+              "Description": "Add a comment to explain how to replace IOwinContext.Request.Headers.Get with TryGetValue instead.",
+              "ActionValidation": {
+                "Contains": "PleasereplaceGetwithTryGetValue.",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -1,0 +1,478 @@
+﻿{
+  "Name": "Owin",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Owin",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Class",
+      "Name": "IAppBuilder",
+      "Value": "Owin.IAppBuilder",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace IAppBuilder with IApplicationBuilder and add the Microsoft.AspNetCore.Builder namespace and the Microsoft.AspNetCore.Diagnostics package and remove the Owin namespace.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Diagnostics",
+              "Description": "Add package Microsoft.AspNetCore.Diagnostics"
+            },
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IApplicationBuilder",
+              "Description": "Replace IAppBuilder with IApplicationBuilder",
+              "ActionValidation": {
+                "Contains": "IApplicationBuilder",
+                "NotContains": "IAppBuilder"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingOwin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Use",
+      "Value": "Owin.IAppBuilder.Use(object, params object[])",
+      "KeyType": "Name",
+      "ContainingType": "IAppBuilder",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with .UseOwin.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Owin.IAppBuilder.Use with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
+              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to UseOwin.",
+              "ActionValidation": {
+                "Contains": "ReplaceOwin.IAppBuilder.Usewith.UseOwin",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Use",
+      "Value": "Owin.IAppBuilder.Use<T>(params object[])",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderUseExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with either .UseMiddleware<MiddlewareNameHere> or .UseOwin.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "If this format is used \".Use<MiddlewareNameHere>\" replace with Microsoft.AspNetCore.Builder.IApplicationBuilder.UseMiddleware<MiddlewareNameHere> otherwise replace with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
+              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to either UseMiddleWare or UseOwin.",
+              "ActionValidation": {
+                "Contains": "replacewithMicrosoft.AspNetCore.Builder.IApplicationBuilder.UseMiddleware<MiddlewareNameHere>otherwisereplacewith.UseOwin",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Use",
+      "Value": "Owin.IAppBuilder.Use(System.Func<Microsoft.Owin.IOwinContext, System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task>)",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderUseExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with .UseOwin.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Owin.IAppBuilder.Use with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
+              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to UseOwin.",
+              "ActionValidation": {
+                "Contains": "ReplaceOwin.IAppBuilder.Usewith.UseOwin",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "UseWebApi",
+      "Value": "Owin.IAppBuilder.UseWebApi(System.Web.Http.HttpConfiguration)",
+      "KeyType": "Name",
+      "ContainingType": "WebApiAppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseEndpoints",
+              "Description": "Replace UseWebApi with UseEndpoints",
+              "ActionValidation": {
+                "Contains": "UseEndpoints",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddControllers(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddControllers();}",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please setup your routes here you can use a lambda function if needed such as IApplicationBuilder.UseEndpoints(endpoints => { endpoints.MapControllers(); } );",
+              "Description": "Add a comment on how to setup your MVC controller in startup class.",
+              "ActionValidation": {
+                "Contains": "IApplicationBuilder.UseEndpoints(endpoints=>{endpoints.MapControllers();});",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Http",
+              "Description": "Remove System.Web.Http namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingSystem.Web.Http;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "MapSignalR",
+      "Value": "Owin.IAppBuilder.MapSignalR()",
+      "KeyType": "Name",
+      "ContainingType": "OwinExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.SignalR package and replace MapSignalR with UseSignalR. Add a comment to add a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.SignalR",
+              "Description": "Add package Microsoft.AspNetCore.SignalR"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseSignalR",
+              "Description": "Replace MapSignalR with UseSignalR",
+              "ActionValidation": {
+                "Contains": "UseSignalR",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddSignalR(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddSignalR();}",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please setup your signalR hub configuration here you can use a lambda function if needed such as .AddSignalR(routes => { routes.MapHub<StronglyTypedChatHub>(\"chathub\")); }",
+              "Description": "Add a comment on how to setup your MVC controller in startup class.",
+              "ActionValidation": {
+                "Contains": "PleasesetupyoursignalRhubconfigurationhere",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "UseErrorPage",
+      "Value": "Owin.IAppBuilder.UseErrorPage()",
+      "KeyType": "Name",
+      "ContainingType": "ErrorPageExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace UseErrorPage with UseDeveloperExceptionPage.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseDeveloperExceptionPage",
+              "Description": "Replace UseErrorPage with UseDeveloperExceptionPage",
+              "ActionValidation": {
+                "Contains": "UseDeveloperExceptionPage",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "UseFileServer",
+      "Value": "Owin.IAppBuilder.UseFileServer(Microsoft.Owin.StaticFiles.FileServerOptions)",
+      "KeyType": "Name",
+      "ContainingType": "FileServerExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to use FileServerOptions and to ensure the usage of FileProvider attribute.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace the FileSystem property inside of the new FileServerOptions with FileProvider instead, if FileSystem is not initialized please add FileProvider.",
+              "Description": "Add a comment on how to setup your MVC controller in startup class.",
+              "ActionValidation": {
+                "Contains": "PleasereplacetheFileSystempropertyinsideofthenewFileServerOptionswithFileProvider",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "UseDirectoryBrowser",
+      "Value": "Owin.IAppBuilder.UseDirectoryBrowser(Microsoft.Owin.StaticFiles.DirectoryBrowserOptions)",
+      "KeyType": "Name",
+      "ContainingType": "DirectoryBrowserExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.Extensions.DependencyInjection namespace. Add a comment to add ConfigureServices method and explain how to use FileProvider attribute inside of DirectoryBrowsingOptions class.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace the FileSystem property inside of the new DirectoryBrowsingOptions with FileProvider instead, if FileSystem is not initialized please add FileProvider.",
+              "Description": "Add a comment on how to setup your MVC controller in startup class.",
+              "ActionValidation": {
+                "Contains": "PleasereplacetheFileSystempropertyinsideofthenewDirectoryBrowsingOptionswithFileProvider",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddDirectoryBrowser(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddDirectoryBrowser();}",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Related issue

Closes: https://github.com/aws/cta/issues/54


## Description
Currently S3 bucket rules take precedence which is causing a problem for new rules that depend on modified rules files. Since the S3 always takes precedence the new PR will always fail their builds since the unit tests are running against the old rules files rather than the new ones.

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
