### PR TITLE
Invocation too vague

### DIFF
--- a/src/CTA.Rules.Analysis/RulesAnalysis.cs
+++ b/src/CTA.Rules.Analysis/RulesAnalysis.cs
@@ -268,9 +268,9 @@ namespace CTA.Rules.Analyzer
                                 }
 
                                 token = null;
-                                if(!string.IsNullOrEmpty(objectCreationNode.SemanticMethodSignature))
+                                if(!string.IsNullOrEmpty(objectCreationNode.SemanticOriginalDefinition))
                                 {
-                                    var nameToken = new ObjectCreationExpressionToken() { Key = objectCreationNode.SemanticClassType, Namespace = objectCreationNode.SemanticNamespace, Type = objectCreationNode.SemanticClassType };
+                                    var nameToken = new ObjectCreationExpressionToken() { Key = objectCreationNode.SemanticOriginalDefinition, Namespace = objectCreationNode.SemanticNamespace, Type = objectCreationNode.SemanticClassType };
                                     _rootNodes.ObjectCreationExpressionTokens.TryGetValue(nameToken, out token);
                                     if (token != null)
                                     {

--- a/src/CTA.Rules.Analysis/RulesAnalysis.cs
+++ b/src/CTA.Rules.Analysis/RulesAnalysis.cs
@@ -184,7 +184,7 @@ namespace CTA.Rules.Analyzer
                         case IdConstants.InvocationIdName:
                             {
                                 InvocationExpression invocationExpression = (InvocationExpression)child;
-                                var compareToken = new InvocationExpressionToken() { Key = invocationExpression.MethodName, Namespace = invocationExpression.Reference.Namespace, Type = invocationExpression.SemanticClassType };
+                                var compareToken = new InvocationExpressionToken() { Key = invocationExpression.SemanticOriginalDefinition, Namespace = invocationExpression.Reference.Namespace, Type = invocationExpression.SemanticClassType };
                                 _rootNodes.Invocationexpressiontokens.TryGetValue(compareToken, out var token);
                                 if (token != null)
                                 {

--- a/src/CTA.Rules.Update/ActionsRewriter.cs
+++ b/src/CTA.Rules.Update/ActionsRewriter.cs
@@ -334,7 +334,7 @@ namespace CTA.Rules.Update.Rewriters
             bool skipChildren = false; // This is here to skip actions on children node when the main identifier was changed. Just use new expression for the subsequent children actions.
             foreach (var action in _fileActions.ObjectCreationExpressionActions)
             {
-                if (newNode.ToString() == action.Key || symbols.Symbol?.ContainingType?.Name == action.Key)
+                if (newNode.ToString() == action.Key || symbols.Symbol?.OriginalDefinition.ToDisplayString() == action.Key)
                 {
                     var actionExecution = new GenericActionExecution(action, _fileActions.FilePath)
                     {

--- a/src/CTA.Rules.Update/ActionsRewriter.cs
+++ b/src/CTA.Rules.Update/ActionsRewriter.cs
@@ -197,33 +197,34 @@ namespace CTA.Rules.Update.Rewriters
 
             var symbol = symbols.Symbol;
 
-            if (symbol != null)
+            if(symbol == null)
             {
-                var nodeKey = symbol.OriginalDefinition.ToString();
+                return node;
+            }
 
-                foreach (var action in _fileActions.InvocationExpressionActions)
+            var nodeKey = symbol.OriginalDefinition.ToString();
+
+            foreach (var action in _fileActions.InvocationExpressionActions)
+            {
+                if (nodeKey == action.Key)
                 {
-                    if (nodeKey == action.Key)
+                    var actionExecution = new GenericActionExecution(action, _fileActions.FilePath)
                     {
-                        var actionExecution = new GenericActionExecution(action, _fileActions.FilePath)
-                        {
-                            TimesRun = 1
-                        };
-                        try
-                        {
-                            newNode = action.InvocationExpressionActionFunc(_syntaxGenerator, newNode);
-                            LogHelper.LogInformation(string.Format("{0}: {1}", node.SpanStart, action.Description));
-                        }
-                        catch (Exception ex)
-                        {
-                            var actionExecutionException = new ActionExecutionException(action.Name, action.Key, ex);
-                            actionExecution.InvalidExecutions = 1;
-                            LogHelper.LogError(actionExecutionException);
-                        }
-                        allActions.Add(actionExecution);
+                        TimesRun = 1
+                    };
+                    try
+                    {
+                        newNode = action.InvocationExpressionActionFunc(_syntaxGenerator, newNode);
+                        LogHelper.LogInformation(string.Format("{0}: {1}", node.SpanStart, action.Description));
                     }
+                    catch (Exception ex)
+                    {
+                        var actionExecutionException = new ActionExecutionException(action.Name, action.Key, ex);
+                        actionExecution.InvalidExecutions = 1;
+                        LogHelper.LogError(actionExecutionException);
+                    }
+                    allActions.Add(actionExecution);
                 }
-            
             }
             return newNode;
         }

--- a/src/CTA.Rules.Update/ActionsRewriter.cs
+++ b/src/CTA.Rules.Update/ActionsRewriter.cs
@@ -199,7 +199,7 @@ namespace CTA.Rules.Update.Rewriters
 
             if (symbol != null)
             {
-                var nodeKey = $"{symbol.ContainingType}.{symbol.Name}";
+                var nodeKey = symbol.OriginalDefinition.ToString();
 
                 foreach (var action in _fileActions.InvocationExpressionActions)
                 {

--- a/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
+++ b/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
@@ -39,6 +39,9 @@
     <None Update="CTAFiles\project.specific.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TempRules\microsoft.owin.hosting.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TempRules\microsoft.owin.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
+++ b/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
@@ -45,6 +45,12 @@
     <None Update="TempRules\microsoft.owin.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TempRules\microsoft.owin.staticfiles.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\owin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TempRules\system.collections.specialized.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -52,6 +58,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TempRules\system.web.configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.web.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/tst/CTA.Rules.Test/CTAFiles/consolidated.json
+++ b/tst/CTA.Rules.Test/CTAFiles/consolidated.json
@@ -31,7 +31,7 @@
           "FullKey": "System.Web.HttpResponse",
           "Methods": [
             {
-              "Key": "AppendHeader",
+              "Key": "System.Web.HttpResponse.AppendHeader(string, string)",
               "FullKey": "System.Web.HttpResponse.AppendHeader(string, string)",
               "Actions": [
                 {
@@ -55,7 +55,7 @@
           "FullKey": "System.Web.HttpServerUtilityBase",
           "Methods": [
             {
-              "Key": "HtmlEncode",
+              "Key": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
               "FullKey": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
               "Actions": [
                 {

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
@@ -1,0 +1,126 @@
+﻿{
+  "Name": "Microsoft.Owin.Hosting",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Hosting",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Hosting",
+      "Value": "Microsoft.Owin.Hosting",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Hosting, Microsoft.AspNetCore.Server.Kestrel and remove Microsoft.Owin.Hosting and Owin.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Hosting",
+              "Description": "Add package Microsoft.AspNetCore.Hosting"
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Server.Kestrel",
+              "Description": "Add package Microsoft.AspNetCore.Server.Kestrel"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Hosting",
+              "Description": "Add Microsoft.AspNetCore.Hosting namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Hosting;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Server.Kestrel",
+              "Description": "Add Microsoft.AspNetCore.Server.Kestrel namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Server.Kestrel;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Hosting",
+              "Description": "Remove Microsoft.Owin.Hosting namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin.Hosting;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingOwin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Hosting.WebApp.Start",
+      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>",
+      "KeyType": "Name",
+      "ContainingType": "WebApp",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace WebApp.Start.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Microsoft.Owin.Hosting.WebApp.Start with WebHostBuilder such as: var host = new WebHostBuilder().UseKestrel().UseUrls(URL_HERE).UseStartup<Startup>().Build(); host.Start();",
+              "Description": "Add a comment to explain how to replace WebApp.Start.",
+              "ActionValidation": {
+                "Contains": "ReplaceMicrosoft.Owin.Hosting.WebApp.StartwithWebHostBuilder",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
@@ -88,8 +88,44 @@
     },
     {
       "Type": "Method",
-      "Name": "Microsoft.Owin.Hosting.WebApp.Start",
-      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>",
+      "Name": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(Microsoft.Owin.Hosting.StartOptions)",
+      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(Microsoft.Owin.Hosting.StartOptions)",
+      "KeyType": "Name",
+      "ContainingType": "WebApp",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace WebApp.Start.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Microsoft.Owin.Hosting.WebApp.Start with WebHostBuilder such as: var host = new WebHostBuilder().UseKestrel().UseUrls(URL_HERE).UseStartup<Startup>().Build(); host.Start();",
+              "Description": "Add a comment to explain how to replace WebApp.Start.",
+              "ActionValidation": {
+                "Contains": "ReplaceMicrosoft.Owin.Hosting.WebApp.StartwithWebHostBuilder",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(string)",
+      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(string)",
       "KeyType": "Name",
       "ContainingType": "WebApp",
       "RecommendedActions": [

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
@@ -321,8 +321,8 @@
     },
     {
       "Type": "Method",
-      "Name": "Invoke",
-      "Value": "Microsoft.Owin.OwinMiddleware.Invoke",
+      "Name": "Microsoft.Owin.OwinMiddleware.Invoke(Microsoft.Owin.IOwinContext)",
+      "Value": "Microsoft.Owin.OwinMiddleware.Invoke(Microsoft.Owin.IOwinContext)",
       "KeyType": "Name",
       "ContainingType": "OwinMiddleware",
       "RecommendedActions": [
@@ -357,7 +357,7 @@
     },
     {
       "Type": "Method",
-      "Name": "Get",
+      "Name": "Microsoft.Owin.IReadableStringCollection.Get(string)",
       "Value": "Microsoft.Owin.IReadableStringCollection.Get(string)",
       "KeyType": "Name",
       "ContainingType": "IReadableStringCollection",

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.staticfiles.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.staticfiles.json
@@ -1,0 +1,190 @@
+﻿{
+  "Name": "Microsoft.Owin.StaticFiles",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.StaticFiles",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "StaticFiles",
+      "Value": "Microsoft.Owin.StaticFiles",
+      "KeyType": "Method",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.StaticFiles and Microsoft.Extensions.FileProviders.Physical packages. Add Microsoft.Extensions.FileProviders and Microsoft.AspNetCore.StaticFiles namespaces. Remove Microsoft.Owin.StaticFiles and Microsoft.Owin.FileSystems namespaces.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.StaticFiles",
+              "Description": "Add package Microsoft.AspNetCore.StaticFiles"
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.Extensions.FileProviders.Physical",
+              "Description": "Add package Microsoft.Extensions.FileProviders.Physical"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.FileProviders",
+              "Description": "Add Microsoft.Extensions.FileProviders",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.FileProviders;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.StaticFiles",
+              "Description": "Add Microsoft.AspNetCore.StaticFiles",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.StaticFiles;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.StaticFiles",
+              "Description": "Remove Microsoft.Owin.StaticFiles namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin.StaticFiles;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.FileSystems",
+              "Description": "Remove Microsoft.Owin.FileSystems namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin.FileSystems;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.StaticFiles.FileServerOptions.FileServerOptions()",
+      "Value": "Microsoft.Owin.StaticFiles.FileServerOptions.FileServerOptions()",
+      "KeyType": "Name",
+      "ContainingType": "FileServerOptions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace FileServerOptions' FileSystem with FileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceOrAddObjectPropertyIdentifier",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "FileSystem",
+                "newMember": "FileProvider",
+                "newValueIfAdding": "new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), @\"\"))"
+              },
+              "Description": "Replace FileServerOptions' FileSystem with FileProvider",
+              "ActionValidation": {
+                "Contains": "FileProvider",
+                "NotContains": "FileSystem"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "If FileSystem was not present before FileProvider was initialized for you, please copy the value from RequestPath into it. You may need to use Directory.GetCurrentDirectory().",
+              "Description": "Add a comment to explain how to initialize FileProvider correctly.",
+              "ActionValidation": {
+                "Contains": "IfFileSystemwasnotpresentbeforeFileProviderwasinitializedforyou,pleasecopythevaluefromRequestPathintoit.YoumayneedtouseDirectory.GetCurrentDirectory().",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.StaticFiles.DirectoryBrowserOptions.DirectoryBrowserOptions()",
+      "Value": "Microsoft.Owin.StaticFiles.DirectoryBrowserOptions.DirectoryBrowserOptions()",
+      "KeyType": "Name",
+      "ContainingType": "DirectoryBrowserOptions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace DirectoryBrowserOptions' FileSystem with FileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceOrAddObjectPropertyIdentifier",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "FileSystem",
+                "newMember": "FileProvider",
+                "newValueIfAdding": "new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), @\"\"))"
+              },
+              "Description": "Replace DirectoryBrowserOptions' FileSystem with FileProvider",
+              "ActionValidation": {
+                "Contains": "FileProvider",
+                "NotContains": "FileSystem"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "If FileSystem was not present before FileProvider was initialized for you, please copy the value from RequestPath into it. You may need to use Directory.GetCurrentDirectory().",
+              "Description": "Add a comment to explain how to initialize FileProvider correctly.",
+              "ActionValidation": {
+                "Contains": "IfFileSystemwasnotpresentbeforeFileProviderwasinitializedforyou,pleasecopythevaluefromRequestPathintoit.YoumayneedtouseDirectory.GetCurrentDirectory().",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -1,0 +1,432 @@
+﻿{
+  "Name": "Owin",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Owin",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Class",
+      "Name": "IAppBuilder",
+      "Value": "Owin.IAppBuilder",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace IAppBuilder with IApplicationBuilder and add the Microsoft.AspNetCore.Builder namespace and the Microsoft.AspNetCore.Diagnostics package and remove the Owin namespace.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Diagnostics",
+              "Description": "Add package Microsoft.AspNetCore.Diagnostics"
+            },
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IApplicationBuilder",
+              "Description": "Replace IAppBuilder with IApplicationBuilder",
+              "ActionValidation": {
+                "Contains": "IApplicationBuilder",
+                "NotContains": "IAppBuilder"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingOwin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.Use(object, params object[])",
+      "Value": "Owin.IAppBuilder.Use(object, params object[])",
+      "KeyType": "Name",
+      "ContainingType": "IAppBuilder",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with .UseOwin.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Owin.IAppBuilder.Use with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
+              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to UseOwin.",
+              "ActionValidation": {
+                "Contains": "ReplaceOwin.IAppBuilder.Usewith.UseOwin",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.Use<T>(params object[])",
+      "Value": "Owin.IAppBuilder.Use<T>(params object[])",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderUseExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with either .UseMiddleware<MiddlewareNameHere> or .UseOwin.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "If this format is used \".Use<MiddlewareNameHere>\" replace with Microsoft.AspNetCore.Builder.IApplicationBuilder.UseMiddleware<MiddlewareNameHere> otherwise replace with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
+              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to either UseMiddleWare or UseOwin.",
+              "ActionValidation": {
+                "Contains": "replacewithMicrosoft.AspNetCore.Builder.IApplicationBuilder.UseMiddleware<MiddlewareNameHere>otherwisereplacewith.UseOwin",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.Use(System.Func<Microsoft.Owin.IOwinContext, System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task>)",
+      "Value": "Owin.IAppBuilder.Use(System.Func<Microsoft.Owin.IOwinContext, System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task>)",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderUseExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with .UseOwin.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Owin.IAppBuilder.Use with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
+              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to UseOwin.",
+              "ActionValidation": {
+                "Contains": "ReplaceOwin.IAppBuilder.Usewith.UseOwin",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseWebApi(System.Web.Http.HttpConfiguration)",
+      "Value": "Owin.IAppBuilder.UseWebApi(System.Web.Http.HttpConfiguration)",
+      "KeyType": "Name",
+      "ContainingType": "WebApiAppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseEndpoints",
+              "Description": "Replace UseWebApi with UseEndpoints",
+              "ActionValidation": {
+                "Contains": "UseEndpoints",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddControllers(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddControllers();}",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please setup your routes here you can use a lambda function if needed such as IApplicationBuilder.UseEndpoints(endpoints => { endpoints.MapControllers(); } );",
+              "Description": "Add a comment on how to setup your MVC controller in startup class.",
+              "ActionValidation": {
+                "Contains": "IApplicationBuilder.UseEndpoints(endpoints=>{endpoints.MapControllers();});",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Http",
+              "Description": "Remove System.Web.Http namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingSystem.Web.Http;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.MapSignalR()",
+      "Value": "Owin.IAppBuilder.MapSignalR()",
+      "KeyType": "Name",
+      "ContainingType": "OwinExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.SignalR package and replace MapSignalR with UseSignalR. Add a comment to add a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.SignalR",
+              "Description": "Add package Microsoft.AspNetCore.SignalR"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseSignalR",
+              "Description": "Replace MapSignalR with UseSignalR",
+              "ActionValidation": {
+                "Contains": "UseSignalR",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddSignalR(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddSignalR();}",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please setup your signalR hub configuration here you can use a lambda function if needed such as .AddSignalR(routes => { routes.MapHub<StronglyTypedChatHub>(\"chathub\")); }",
+              "Description": "Add a comment on how to setup your MVC controller in startup class.",
+              "ActionValidation": {
+                "Contains": "PleasesetupyoursignalRhubconfigurationhere",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseErrorPage()",
+      "Value": "Owin.IAppBuilder.UseErrorPage()",
+      "KeyType": "Name",
+      "ContainingType": "ErrorPageExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace UseErrorPage with UseDeveloperExceptionPage.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseDeveloperExceptionPage",
+              "Description": "Replace UseErrorPage with UseDeveloperExceptionPage",
+              "ActionValidation": {
+                "Contains": "UseDeveloperExceptionPage",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseDirectoryBrowser(Microsoft.Owin.StaticFiles.DirectoryBrowserOptions)",
+      "Value": "Owin.IAppBuilder.UseDirectoryBrowser(Microsoft.Owin.StaticFiles.DirectoryBrowserOptions)",
+      "KeyType": "Name",
+      "ContainingType": "DirectoryBrowserExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.Extensions.DependencyInjection namespace. Add a comment to add ConfigureServices method and explain how to use FileProvider attribute inside of DirectoryBrowsingOptions class.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddDirectoryBrowser(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddDirectoryBrowser();}",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.web.json
+++ b/tst/CTA.Rules.Test/TempRules/system.web.json
@@ -1,0 +1,152 @@
+{
+  "Name": "System.Web",
+  "Version": "1.0.0",
+  "Source": "Github",
+  "Packages": [
+    {
+      "Name": "System.Web",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Method",
+      "Name": "System.Web.HttpResponse.AppendHeader(string, string)",
+      "Value": "System.Web.HttpResponse.AppendHeader(string, string)",
+      "KeyType": "Name",
+      "ContainingType": "HttpResponse",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace method AppendHeader with this.Response.Headers.Add. In the replacement, \"this\" refers to the controller object.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "this.Response.Headers.Add",
+              "Description": "Replace AppendHeader with a new method to add to headers.",
+              "ActionValidation": {
+                "Contains": "this.Response.Headers.Add",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "In this context, this is a Controller object",
+              "Description": "Add a comment to explain what \"this\" refers to.",
+              "ActionValidation": {
+                "Contains": "thisisaControllerobject",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
+      "Value": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
+      "KeyType": "Name",
+      "ContainingType": "HttpServerUtilityBase",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace HtmlEncode with a new method HtmlEncoder.Default.Encode in namepsace System.Text.Encodings.Web.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethod",
+              "Type": "Method",
+              "Value": "HtmlEncoder.Default.Encode",
+              "Description": "Replace HtmlEncode with a new method: HtmlEncoder.Default.Encode.",
+              "ActionValidation": {
+                "Contains": "HtmlEncoder.Default.Encode",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "System.Text.Encodings.Web",
+              "Description": "Add System.Text.Encodings.Web.",
+              "ActionValidation": {
+                "Contains": "usingSystem.Text.Encodings.Web;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "HttpContextBase",
+      "Value": "System.Web.HttpContextBase",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace HttpContextBase in namespace System.Web with HttpContext in namespace Microsoft.AspNetCore.Http.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpContext",
+              "Description": "Replace HttpContextBase with HttpContext.",
+              "ActionValidation":{"Contains":"HttpContext", "NotContains":""}
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace.",
+              "ActionValidation":{"Contains":"usingMicrosoft.AspNetCore.Http;", "NotContains":""}
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web",
+              "Description": "Remove System.Web namespace.",
+              "ActionValidation":{"Contains":"", "NotContains":"usingSystem.Web;"}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Related issue

Closes: #66 


## Description
The invocation expressions keys are too imprecise causing false positive matches against methods of the same name in other namespaces. This makes the key more specific and prevents this from happening. 

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
