### PR TITLE
Add new replace only method action and fix owin rules

### DIFF
--- a/src/CTA.Rules.Actions/InvocationExpressionActions.cs
+++ b/src/CTA.Rules.Actions/InvocationExpressionActions.cs
@@ -23,6 +23,17 @@ namespace CTA.Rules.Actions
             return ReplaceMethod;
         }
 
+        public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceOnlyMethodAction(string oldMethod, string newMethod)
+        {
+            //TODO what's the outcome if newMethod doesn't have a valid signature.. are there any options we could provide to parseexpression ?
+            InvocationExpressionSyntax ReplaceOnlyMethod(SyntaxGenerator syntaxGenerator, InvocationExpressionSyntax node)
+            {
+                node = node.WithExpression(SyntaxFactory.ParseExpression(node.Expression.ToString().Replace(oldMethod, newMethod))).NormalizeWhitespace();
+                return node;
+            }
+            return ReplaceOnlyMethod;
+        }
+
         public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetAppendMethodAction(string appendMethod)
         {
             InvocationExpressionSyntax ReplaceMethod(SyntaxGenerator syntaxGenerator, InvocationExpressionSyntax node)

--- a/src/CTA.Rules.Actions/InvocationExpressionActions.cs
+++ b/src/CTA.Rules.Actions/InvocationExpressionActions.cs
@@ -13,12 +13,33 @@ namespace CTA.Rules.Actions
     public class InvocationExpressionActions
     {
         /// <summary>
+        /// This Method replaces the entire expression including the parameters. For example, Math.Round(5.5) invocation expression matching on Round with a newMethod parameter of Abs(9.5) would return Abs(9.5) not Math.Abs(9.5).
+        /// Please ensure to include the prefix part of the matching invocation expression since this method will replace it and the parameters as well.
+        /// </summary>
+        /// <param name="newMethod">The new invocation expression including the method to replace with and the parameters.</param>
+        /// <param name="newParameters">The new invocation expression parameters to replace the old parameters with.</param>
+        /// <returns></returns>
+        public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceMethodWithObjectAndParametersAction(string newMethod, string newParameters)
+        {
+            //TODO what's the outcome if newMethod doesn't have a valid signature.. are there any options we could provide to parseexpression ?
+            InvocationExpressionSyntax ReplaceMethod(SyntaxGenerator syntaxGenerator, InvocationExpressionSyntax node)
+            {
+                node = SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.IdentifierName(newMethod),
+                        SyntaxFactory.ParseArgumentList(newParameters))
+                    .NormalizeWhitespace();
+                return node;
+            }
+            return ReplaceMethod;
+        }
+
+        /// <summary>
         /// This Method replaces the entire expression up to the matching invocation expression. For example, Math.Round(5.5) invocation expression matching on Round with a newMethod parameter of Abs would return Abs(5.5) not Math.Abs(5.5).
         /// Please ensure to include the prefix part of the matching invocation expression since this method will replace it.
         /// </summary>
         /// <param name="newMethod">The new invocation expression including the method to replace with.</param>
         /// <returns></returns>
-        public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceMethodAction(string newMethod)
+        public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceMethodWithObjectAction(string newMethod)
         {
             //TODO what's the outcome if newMethod doesn't have a valid signature.. are there any options we could provide to parseexpression ?
             InvocationExpressionSyntax ReplaceMethod(SyntaxGenerator syntaxGenerator, InvocationExpressionSyntax node)
@@ -30,12 +51,31 @@ namespace CTA.Rules.Actions
         }
 
         /// <summary>
+        /// This Method replaces only matching method in the invocation expression and its parameters.
+        /// For example, Math.Round(5.5) invocation expression matching on Round with a newMethod parameter of Abs and an oldMethod parameter of Round with parameters of 8.5 would return Math.Abs(8.5).
+        /// </summary>
+        /// <param name="oldMethod">The matching method in the invocation expression to be replaced.</param>
+        /// <param name="newMethod">The new method to replace the old method with in the invocation expression.</param>
+        /// <param name="newParameters">The new invocation expression parameters to replace the old parameters with.</param>
+        /// <returns></returns>
+        public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceMethodAndParametersAction(string oldMethod, string newMethod, string newParameters)
+        {
+            //TODO what's the outcome if newMethod doesn't have a valid signature.. are there any options we could provide to parseexpression ?
+            InvocationExpressionSyntax ReplaceOnlyMethod(SyntaxGenerator syntaxGenerator, InvocationExpressionSyntax node)
+            {
+                node = node.WithExpression(SyntaxFactory.ParseExpression(node.Expression.ToString().Replace(oldMethod, newMethod))).WithArgumentList(SyntaxFactory.ParseArgumentList(newParameters)).NormalizeWhitespace();
+                return node;
+            }
+            return ReplaceOnlyMethod;
+        }
+
+        /// <summary>
         /// This Method replaces only matching method in the invocation expression. For example, Math.Round(5.5) invocation expression matching on Round with a newMethod parameter of Abs and an oldMethod parameter of Round would return Math.Abs(5.5).
         /// </summary>
         /// <param name="oldMethod">The matching method in the invocation expression to be replaced.</param>
         /// <param name="newMethod">The new method to replace the old method with in the invocation expression.</param>
         /// <returns></returns>
-        public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceOnlyMethodAction(string oldMethod, string newMethod)
+        public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceMethodOnlyAction(string oldMethod, string newMethod)
         {
             //TODO what's the outcome if newMethod doesn't have a valid signature.. are there any options we could provide to parseexpression ?
             InvocationExpressionSyntax ReplaceOnlyMethod(SyntaxGenerator syntaxGenerator, InvocationExpressionSyntax node)

--- a/src/CTA.Rules.Actions/InvocationExpressionActions.cs
+++ b/src/CTA.Rules.Actions/InvocationExpressionActions.cs
@@ -12,6 +12,12 @@ namespace CTA.Rules.Actions
     /// </summary>
     public class InvocationExpressionActions
     {
+        /// <summary>
+        /// This Method replaces the entire expression up to the matching invocation expression. For example, Math.Round(5.5) invocation expression matching on Round with a newMethod parameter of Abs would return Abs(5.5) not Math.Abs(5.5).
+        /// Please ensure to include the prefix part of the matching invocation expression since this method will replace it.
+        /// </summary>
+        /// <param name="newMethod">The new invocation expression including the method to replace with.</param>
+        /// <returns></returns>
         public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceMethodAction(string newMethod)
         {
             //TODO what's the outcome if newMethod doesn't have a valid signature.. are there any options we could provide to parseexpression ?
@@ -23,6 +29,12 @@ namespace CTA.Rules.Actions
             return ReplaceMethod;
         }
 
+        /// <summary>
+        /// This Method replaces only matching method in the invocation expression. For example, Math.Round(5.5) invocation expression matching on Round with a newMethod parameter of Abs and an oldMethod parameter of Round would return Math.Abs(5.5).
+        /// </summary>
+        /// <param name="oldMethod">The matching method in the invocation expression to be replaced.</param>
+        /// <param name="newMethod">The new method to replace the old method with in the invocation expression.</param>
+        /// <returns></returns>
         public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceOnlyMethodAction(string oldMethod, string newMethod)
         {
             //TODO what's the outcome if newMethod doesn't have a valid signature.. are there any options we could provide to parseexpression ?

--- a/src/CTA.Rules.Analysis/RulesAnalysis.cs
+++ b/src/CTA.Rules.Analysis/RulesAnalysis.cs
@@ -184,6 +184,10 @@ namespace CTA.Rules.Analyzer
                         case IdConstants.InvocationIdName:
                             {
                                 InvocationExpression invocationExpression = (InvocationExpression)child;
+
+                                ////If we don't have a semantic analysis, we dont want to replace invocation expressions, otherwise we'll be replacing expressions regardless of their class/namespace
+                                if (string.IsNullOrEmpty(invocationExpression.SemanticOriginalDefinition)) break;
+
                                 var compareToken = new InvocationExpressionToken() { Key = invocationExpression.SemanticOriginalDefinition, Namespace = invocationExpression.Reference.Namespace, Type = invocationExpression.SemanticClassType };
                                 _rootNodes.Invocationexpressiontokens.TryGetValue(compareToken, out var token);
                                 if (token != null)

--- a/tst/CTA.Rules.Test/Actions/InvocationExpressionActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/InvocationExpressionActionsTests.cs
@@ -25,6 +25,30 @@ namespace CTA.Rules.Test.Actions
         }
 
         [Test]
+        public void GetReplaceMethodAction()
+        {
+            const string newMethod = "Math.Floor";
+            var appendMethodFunc =
+                _invocationExpressionActions.GetReplaceMethodAction(newMethod);
+            var newNode = appendMethodFunc(_syntaxGenerator, _node);
+
+            var expectedResult = "Math.Floor(-1)";
+            Assert.AreEqual(expectedResult, newNode.ToFullString());
+        }
+
+        [Test]
+        public void GetReplaceOnlyMethodAction()
+        {
+            const string newMethod = "Floor";
+            var appendMethodFunc =
+                _invocationExpressionActions.GetReplaceOnlyMethodAction("Abs",newMethod);
+            var newNode = appendMethodFunc(_syntaxGenerator, _node);
+
+            var expectedResult = "Math.Floor(-1)";
+            Assert.AreEqual(expectedResult, newNode.ToFullString());
+        }
+
+        [Test]
         public void GetAppendMethodAction_Appends_A_Method_Invocation()
         {
             const string invocationToAppend = "ToString()";

--- a/tst/CTA.Rules.Test/Actions/InvocationExpressionActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/InvocationExpressionActionsTests.cs
@@ -25,11 +25,24 @@ namespace CTA.Rules.Test.Actions
         }
 
         [Test]
-        public void GetReplaceMethodAction()
+        public void GetReplaceMethodWithObjectAndParametersAction()
+        {
+            const string newMethod = "Math.Floor";
+            const string newParameter = "(-2)";
+            var appendMethodFunc =
+                _invocationExpressionActions.GetReplaceMethodWithObjectAndParametersAction(newMethod, newParameter);
+            var newNode = appendMethodFunc(_syntaxGenerator, _node);
+
+            var expectedResult = "Math.Floor(-2)";
+            Assert.AreEqual(expectedResult, newNode.ToFullString());
+        }
+
+        [Test]
+        public void GetReplaceMethodWithObjectAction()
         {
             const string newMethod = "Math.Floor";
             var appendMethodFunc =
-                _invocationExpressionActions.GetReplaceMethodAction(newMethod);
+                _invocationExpressionActions.GetReplaceMethodWithObjectAction(newMethod);
             var newNode = appendMethodFunc(_syntaxGenerator, _node);
 
             var expectedResult = "Math.Floor(-1)";
@@ -37,11 +50,24 @@ namespace CTA.Rules.Test.Actions
         }
 
         [Test]
-        public void GetReplaceOnlyMethodAction()
+        public void GetReplaceMethodAndParametersAction()
+        {
+            const string newMethod = "Floor";
+            const string newParameter = "(-2)";
+            var appendMethodFunc =
+                _invocationExpressionActions.GetReplaceMethodAndParametersAction("Abs", newMethod, newParameter);
+            var newNode = appendMethodFunc(_syntaxGenerator, _node);
+
+            var expectedResult = "Math.Floor(-2)";
+            Assert.AreEqual(expectedResult, newNode.ToFullString());
+        }
+
+        [Test]
+        public void GetReplaceMethodOnlyAction()
         {
             const string newMethod = "Floor";
             var appendMethodFunc =
-                _invocationExpressionActions.GetReplaceOnlyMethodAction("Abs",newMethod);
+                _invocationExpressionActions.GetReplaceMethodOnlyAction("Abs",newMethod);
             var newNode = appendMethodFunc(_syntaxGenerator, _node);
 
             var expectedResult = "Math.Floor(-1)";

--- a/tst/CTA.Rules.Test/CTAFiles/consolidated.json
+++ b/tst/CTA.Rules.Test/CTAFiles/consolidated.json
@@ -35,7 +35,7 @@
               "FullKey": "System.Web.HttpResponse.AppendHeader(string, string)",
               "Actions": [
                 {
-                  "Name": "ReplaceMethod",
+                  "Name": "ReplaceMethodWithObject",
                   "Type": "Method",
                   "Value": "this.Response.Headers.Add",
                   "Description": "Replace AppendHeader with a new method to add to headers"
@@ -59,7 +59,7 @@
               "FullKey": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
               "Actions": [
                 {
-                  "Name": "ReplaceMethod",
+                  "Name": "ReplaceMethodWithObject",
                   "Type": "Method",
                   "Value": "HtmlEncoder.Default.Encode",
                   "Description": "Replace HtmlEncode with a new method: HtmlEncoder.Default.Encode"

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
@@ -264,7 +264,7 @@
           "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceMethodWithObject",
               "Type": "Method",
               "Value": "_next.Invoke",
               "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -201,9 +201,12 @@
           "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceOnlyMethod",
               "Type": "Method",
-              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseEndpoints",
+              "Value": {
+                "oldMethod": "UseWebApi",
+                "newMethod": "UseEndpoints"
+              },
               "Description": "Replace UseWebApi with UseEndpoints",
               "ActionValidation": {
                 "Contains": "UseEndpoints",
@@ -313,9 +316,12 @@
               }
             },
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceOnlyMethod",
               "Type": "Method",
-              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseSignalR",
+              "Value": {
+                "oldMethod": "MapSignalR",
+                "newMethod": "UseSignalR"
+              },
               "Description": "Replace MapSignalR with UseSignalR",
               "ActionValidation": {
                 "Contains": "UseSignalR",
@@ -369,9 +375,12 @@
           "Description": "Replace UseErrorPage with UseDeveloperExceptionPage.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceOnlyMethod",
               "Type": "Method",
-              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseDeveloperExceptionPage",
+              "Value": {
+                "oldMethod": "UseErrorPage",
+                "newMethod": "UseDeveloperExceptionPage"
+              },
               "Description": "Replace UseErrorPage with UseDeveloperExceptionPage",
               "ActionValidation": {
                 "Contains": "UseDeveloperExceptionPage",

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -201,7 +201,7 @@
           "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
           "Actions": [
             {
-              "Name": "ReplaceOnlyMethod",
+              "Name": "ReplaceMethodOnly",
               "Type": "Method",
               "Value": {
                 "oldMethod": "UseWebApi",
@@ -316,7 +316,7 @@
               }
             },
             {
-              "Name": "ReplaceOnlyMethod",
+              "Name": "ReplaceMethodOnly",
               "Type": "Method",
               "Value": {
                 "oldMethod": "MapSignalR",
@@ -375,7 +375,7 @@
           "Description": "Replace UseErrorPage with UseDeveloperExceptionPage.",
           "Actions": [
             {
-              "Name": "ReplaceOnlyMethod",
+              "Name": "ReplaceMethodOnly",
               "Type": "Method",
               "Value": {
                 "oldMethod": "UseErrorPage",

--- a/tst/CTA.Rules.Test/TempRules/system.web.json
+++ b/tst/CTA.Rules.Test/TempRules/system.web.json
@@ -32,7 +32,7 @@
           "Description": "Replace method AppendHeader with this.Response.Headers.Add. In the replacement, \"this\" refers to the controller object.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceMethodWithObject",
               "Type": "Method",
               "Value": "this.Response.Headers.Add",
               "Description": "Replace AppendHeader with a new method to add to headers.",
@@ -78,7 +78,7 @@
           "Description": "Replace HtmlEncode with a new method HtmlEncoder.Default.Encode in namepsace System.Text.Encodings.Web.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceMethodWithObject",
               "Type": "Method",
               "Value": "HtmlEncoder.Default.Encode",
               "Description": "Replace HtmlEncode with a new method: HtmlEncoder.Default.Encode.",


### PR DESCRIPTION
## Related issue

Closes: #78 


## Description
Add a new action for replacing only the method we match against.

## Supplemental testing
Owin rules were replaced and all unit tests passed.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
