### PR TITLE
Make PhysicalFileSystems rule more globally applicable.

### DIFF
--- a/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
+++ b/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
@@ -31,6 +31,9 @@
     <None Update="CTAFiles\action.namespace.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TempRules\microsoft.owin.filesystems.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestFiles\Configs\Web.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -331,9 +331,10 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"PhysicalFileProvider", startupText);
             StringAssert.Contains(@"FileProvider", startupText);
             StringAssert.Contains(@"If FileSystem was not present before FileProvider was added", startupText);
+            StringAssert.DoesNotContain(@"PhysicalFileSystems", startupText);
             StringAssert.DoesNotContain(@"Microsoft.Owin.StaticFiles", startupText);
             StringAssert.DoesNotContain(@"Microsoft.Owin.FileSystems", startupText);
-
+ 
             StringAssert.Contains("WebHostBuilder", programText);
 
             //Check that package has been added:

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.filesystems.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.filesystems.json
@@ -1,0 +1,48 @@
+{
+  "Name": "Microsoft.Owin.FileSystems",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.FileSystems",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Class",
+      "Name": "PhysicalFileSystem",
+      "Value": "Microsoft.Owin.FileSystems.PhysicalFileSystem",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace PhysicalFileSystem with PhysicalFileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "PhysicalFileProvider",
+              "Description": "Replace PhysicalFileSystem with PhysicalFileProvider",
+              "ActionValidation": {
+                "Contains": "PhysicalFileProvider",
+                "NotContains": "PhysicalFileSystem"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Related issue

Closes: #95


## Description
Currently PhysicalFileSystems owin rule only aplpies to object creation types of nodes. It should apply everywhere.

## Supplemental testing
Test with new unit tests.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
