### PR TITLE
Action validations

### DIFF
--- a/src/CTA.FeatureDetection.Common/Extensions/SyntaxNodeExtensions.cs
+++ b/src/CTA.FeatureDetection.Common/Extensions/SyntaxNodeExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace CTA.FeatureDetection.Common.Extensions
+{
+    public static class SyntaxNodeExtensions
+    {
+        public static SyntaxNode NoComments(this SyntaxNode node)
+        {
+            if (node != null)
+            {
+                var childNodes = node.ChildNodes();
+                node = node.ReplaceNodes(childNodes, (node, returnedNode) => node.NoComments());
+                node = node.WithoutTrivia();
+            }
+            return node;
+        }
+    }
+}

--- a/src/CTA.Rules.Models/Actions/ActionValidation.cs
+++ b/src/CTA.Rules.Models/Actions/ActionValidation.cs
@@ -4,5 +4,6 @@
     {
         public string Contains { get; set; }
         public string NotContains { get; set; }
+        public string CheckComments { get; set; }
     }
 }

--- a/src/CTA.Rules.Update/ActionsRewriter.cs
+++ b/src/CTA.Rules.Update/ActionsRewriter.cs
@@ -357,7 +357,6 @@ namespace CTA.Rules.Update.Rewriters
                         actionExecution.InvalidExecutions = 1;
                         LogHelper.LogError(actionExecutionException);
                     }
-                    allActions.Add(actionExecution);
                 }
             }
             if (!skipChildren)

--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -330,7 +330,8 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"Microsoft.AspNetCore.StaticFiles", startupText);
             StringAssert.Contains(@"PhysicalFileProvider", startupText);
             StringAssert.Contains(@"FileProvider", startupText);
-            StringAssert.Contains(@"If FileSystem was not present before FileProvider was added", startupText);
+            StringAssert.Contains(@"For FileServerOptions, if FileSystem was not present before FileProvider was added", startupText);
+            StringAssert.Contains(@"For DirectoryBrowserOptions, if FileSystem was not present before FileProvider was added", startupText);
             StringAssert.DoesNotContain(@"PhysicalFileSystems", startupText);
             StringAssert.DoesNotContain(@"Microsoft.Owin.StaticFiles", startupText);
             StringAssert.DoesNotContain(@"Microsoft.Owin.FileSystems", startupText);

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
@@ -115,7 +115,8 @@
               "Description": "Add a comment to explain how to replace WebApp.Start.",
               "ActionValidation": {
                 "Contains": "ReplaceMicrosoft.Owin.Hosting.WebApp.StartwithWebHostBuilder",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments":  "True" 
               }
             }
           ]
@@ -151,7 +152,8 @@
               "Description": "Add a comment to explain how to replace WebApp.Start.",
               "ActionValidation": {
                 "Contains": "ReplaceMicrosoft.Owin.Hosting.WebApp.StartwithWebHostBuilder",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
@@ -156,18 +156,14 @@
                 "modifiers": "public"
               },
               "Description": "Replace all the invoke method modifiers with only public in order to remove the override modifier.",
-              "ActionValidation": {
-                "Contains": "public",
-                "NotContains": "override"
-              }
             },
             {
               "Name": "AddExpression",
               "Type": "Class",
-              "Value": "RequestDelegate _next = null; //CTA Change",
+              "Value": "RequestDelegate _next = null;",
               "Description": "Add a new global variable to replace the OwinMiddleware global abstract variable of Next.",
               "ActionValidation": {
-                "Contains": "RequestDelegate_next=null;//CTAChange",
+                "Contains": "RequestDelegate_next=null;",
                 "NotContains": ""
               }
             },
@@ -306,7 +302,8 @@
               "Description": "Add a comment to explain how to replace IOwinContext.Request.Headers.Get with TryGetValue instead.",
               "ActionValidation": {
                 "Contains": "PleasereplaceGetwithTryGetValue.",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.staticfiles.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.staticfiles.json
@@ -129,7 +129,7 @@
                 "oldMember": "PhysicalFileSystem",
                 "newMember": "PhysicalFileProvider"
               },
-              "Description": "Replace PhysicalFileSystem with PhysicalFileProvider",
+              "Description": "Replace FileServerOptions' PhysicalFileSystem with PhysicalFileProvider",
               "ActionValidation": {
                 "Contains": "PhysicalFileProvider",
                 "NotContains": "PhysicalFileSystem"
@@ -138,11 +138,12 @@
             {
               "Name": "AddComment",
               "Type": "ObjectCreation",
-              "Value": "If FileSystem was not present before FileProvider was added, please initialize this new value. Using the value from RequestPath with System.IO.Directory.GetCurrentDirectory() as a prefix may be  agood starting point.",
-              "Description": "Add a comment to explain how to initialize FileProvider correctly.",
+              "Value": "For FileServerOptions, if FileSystem was not present before FileProvider was added, please initialize this new value. Using the value from RequestPath with System.IO.Directory.GetCurrentDirectory() as a prefix may be a good starting point.",
+              "Description": "Add a comment to explain how to initialize FileProvider correctly for FileServerOptions.",
               "ActionValidation": {
-                "Contains": "IfFileSystemwasnotpresentbeforeFileProviderwasadded,pleaseinitializethisnewvalue.",
-                "NotContains": ""
+                "Contains": "For FileServerOptions, if FileSystem was not present before FileProvider was added, please initialize this new value.",
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]
@@ -192,7 +193,7 @@
                 "oldMember": "PhysicalFileSystem",
                 "newMember": "PhysicalFileProvider"
               },
-              "Description": "Replace PhysicalFileSystem with PhysicalFileProvider",
+              "Description": "Replace DirectoryBrowserOptions' PhysicalFileSystem with PhysicalFileProvider",
               "ActionValidation": {
                 "Contains": "PhysicalFileProvider",
                 "NotContains": "PhysicalFileSystem"
@@ -201,11 +202,12 @@
             {
               "Name": "AddComment",
               "Type": "ObjectCreation",
-              "Value": "If FileSystem was not present before FileProvider was added, please initialize this new value. Using the value from RequestPath with System.IO.Directory.GetCurrentDirectory() as a prefix may be  agood starting point.",
-              "Description": "Add a comment to explain how to initialize FileProvider correctly.",
+              "Value": "For DirectoryBrowserOptions, if FileSystem was not present before FileProvider was added, please initialize this new value. Using the value from RequestPath with System.IO.Directory.GetCurrentDirectory() as a prefix may be a good starting point.",
+              "Description": "Add a comment to explain how to initialize FileProvider correctly for DirectoryBrowserOptions.",
               "ActionValidation": {
-                "Contains": "IfFileSystemwasnotpresentbeforeFileProviderwasadded,pleaseinitializethisnewvalue.",
-                "NotContains": ""
+                "Contains": "For DirectoryBrowserOptions, if FileSystem was not present before FileProvider was added, please initialize this new value.",
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -99,7 +99,8 @@
               "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to UseOwin.",
               "ActionValidation": {
                 "Contains": "ReplaceOwin.IAppBuilder.Usewith.UseOwin",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]
@@ -135,7 +136,8 @@
               "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to either UseMiddleWare or UseOwin.",
               "ActionValidation": {
                 "Contains": "replacewithMicrosoft.AspNetCore.Builder.IApplicationBuilder.UseMiddleware<MiddlewareNameHere>otherwisereplacewith.UseOwin",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]
@@ -171,7 +173,8 @@
               "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to UseOwin.",
               "ActionValidation": {
                 "Contains": "ReplaceOwin.IAppBuilder.Usewith.UseOwin",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]
@@ -217,7 +220,8 @@
               "Description": "Add a comment on adding a new configureservices method.",
               "ActionValidation": {
                 "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddControllers();}",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             },
             {
@@ -227,7 +231,8 @@
               "Description": "Add a comment on how to setup your MVC controller in startup class.",
               "ActionValidation": {
                 "Contains": "IApplicationBuilder.UseEndpoints(endpoints=>{endpoints.MapControllers();});",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             },
             {
@@ -329,7 +334,8 @@
               "Description": "Add a comment on adding a new configureservices method.",
               "ActionValidation": {
                 "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddSignalR();}",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             },
             {
@@ -339,7 +345,8 @@
               "Description": "Add a comment on how to setup your MVC controller in startup class.",
               "ActionValidation": {
                 "Contains": "PleasesetupyoursignalRhubconfigurationhere",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]
@@ -421,7 +428,8 @@
               "Description": "Add a comment on adding a new configureservices method.",
               "ActionValidation": {
                 "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddDirectoryBrowser();}",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]

--- a/tst/CTA.Rules.Test/TempRules/system.web.json
+++ b/tst/CTA.Rules.Test/TempRules/system.web.json
@@ -48,7 +48,8 @@
               "Description": "Add a comment to explain what \"this\" refers to.",
               "ActionValidation": {
                 "Contains": "thisisaControllerobject",
-                "NotContains": ""
+                "NotContains": "",
+                "CheckComments": "True"
               }
             }
           ]


### PR DESCRIPTION
## Related issue

Closes: #13 


## Description
Added a new action validation field for checking comments, otherwise a regex is run to remove all strings and comments from final files to check action validations. Updates all relevant rules file to include this new check if needed. Also removed a bug with ActionRewriters which was doubling all actions.

## Supplemental testing
All unit tests were checked for validity of actions and all passed.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
