### PR TITLE
Add new IOwin objects Request and response

### DIFF
--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -82,6 +82,8 @@ namespace CTA.Rules.Test
 
             StringAssert.Contains(@"using Microsoft.AspNetCore.Http", displayText);
             StringAssert.Contains(@"HttpContext ", displayText);
+            StringAssert.Contains(@"HttpRequest ", displayText);
+            StringAssert.Contains(@"HttpResponse ", displayText);
             StringAssert.Contains(@"RequestDelegate ", displayText);
             StringAssert.Contains(@"TryGetValue", displayText);
             StringAssert.Contains(@"RequestDelegate _next", displayText);
@@ -92,6 +94,7 @@ namespace CTA.Rules.Test
 
             StringAssert.Contains(@"using Microsoft.AspNetCore.Http", addText);
             StringAssert.Contains(@"HttpContext ", addText);
+            StringAssert.Contains(@"HttpRequest ", addText);
             StringAssert.Contains(@"RequestDelegate ", addText);
             StringAssert.Contains(@"_next", addText);
             StringAssert.Contains(@"RequestDelegate _next", addText);

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
@@ -90,7 +90,7 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Replace IOwinContext with HttpContext and add Microsoft.AspNetCore.Http.HttpContext namespace.",
+          "Description": "Replace IOwinContext with HttpContext and add Microsoft.AspNetCore.Http namespace.",
           "Actions": [
             {
               "Name": "ReplaceIdentifier",
@@ -100,6 +100,98 @@
               "ActionValidation": {
                 "Contains": "HttpContext",
                 "NotContains": "IOwinContext"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IOwinResponse",
+      "Value": "Microsoft.Owin.IOwinResponse",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace IOwinResponse with HttpResponse and add Microsoft.AspNetCore.Http namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpResponse",
+              "Description": "Replace IOwinResponse with HttpResponse",
+              "ActionValidation": {
+                "Contains": "HttpResponse",
+                "NotContains": "IOwinResponse"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IOwinRequest",
+      "Value": "Microsoft.Owin.IOwinRequest",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace IOwinRequest with HttpRequest and add Microsoft.AspNetCore.Http namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpRequest",
+              "Description": "Replace IOwinRequest with HttpRequest",
+              "ActionValidation": {
+                "Contains": "HttpRequest",
+                "NotContains": "IOwinRequest"
               }
             },
             {


### PR DESCRIPTION
## Related issue

Closes: #103 


## Description
We currently do not have rules to support Microsoft.Owin.IOwinRequest and Microsoft.Owin.IOwinResponse.

## Supplemental testing
Modified an owin test project to contain these new objects and created new unit tests to cover these.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
