### PR TITLE
PathString and OpenIdConnect

### DIFF
--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -367,9 +367,15 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"MapControllers", startupText);
             StringAssert.Contains(@"Microsoft.AspNetCore.Builder", startupText);
             StringAssert.Contains(@"Microsoft.Extensions.DependencyInjection", startupText);
-
+            StringAssert.DoesNotContain(@"UseOpenIdConnectAuthentication", startupText);
+            StringAssert.Contains(@"UseAuthentication", startupText);
+            StringAssert.Contains(@"Please add services.AddAuthentication().AddOpenIdConnect();", startupText);
+            StringAssert.Contains(@"Microsoft.AspNetCore.Authentication.OpenIdConnect", startupText);
+            StringAssert.DoesNotContain(@"Microsoft.Owin.Security.OpenIdConnect", startupText);
+    
             //Check that package has been added:
-            StringAssert.Contains(@"Microsoft.AspNetCore.Diagnostics", csProjContent);
+            StringAssert.Contains(version == TargetFramework.Dotnet5 ? @"Microsoft.AspNetCore.Diagnostics" : @"<PackageReference Include=""Microsoft.AspNetCore.Authentication.OpenIdConnect"" Version=""3.1.15"" />", csProjContent);
+            StringAssert.Contains(@"Microsoft.AspNetCore.Authentication.OpenIdConnect", csProjContent);
 
             //Check that correct version is used
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
@@ -623,6 +623,52 @@
           ]
         }
       ]
+    },
+    {
+      "Type": "Class",
+      "Name": "PathString",
+      "Value": "Microsoft.Owin.PathString",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Http namespace if PathString is being used.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin",
+              "Description": "Remove Microsoft.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin;"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -552,6 +552,286 @@
           ]
         }
       ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(string, string)",
+      "Value": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(string, string)",
+      "KeyType": "Name",
+      "ContainingType": "OpenIdConnectAuthenticationExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "3.1.15"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect version 3.1.15"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions)",
+      "Value": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions)",
+      "KeyType": "Name",
+      "ContainingType": "OpenIdConnectAuthenticationExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "3.1.15"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect version 3.1.15"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -204,11 +204,12 @@
           "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
           "Actions": [
             {
-              "Name": "ReplaceMethodOnly",
+              "Name": "ReplaceMethodAndParameters",
               "Type": "Method",
               "Value": {
                 "oldMethod": "UseWebApi",
-                "newMethod": "UseEndpoints"
+                "newMethod": "UseEndpoints",
+                "newParameters": "(endpoints => { endpoints.MapControllers(); })"
               },
               "Description": "Replace UseWebApi with UseEndpoints",
               "ActionValidation": {
@@ -223,17 +224,6 @@
               "Description": "Add a comment on adding a new configureservices method.",
               "ActionValidation": {
                 "Contains": "publicvoidConfigureServices(IServiceCollectionservices){services.AddControllers();}",
-                "NotContains": "",
-                "CheckComments": "True"
-              }
-            },
-            {
-              "Name": "AddComment",
-              "Type": "Method",
-              "Value": "Please setup your routes here you can use a lambda function if needed such as IApplicationBuilder.UseEndpoints(endpoints => { endpoints.MapControllers(); } );",
-              "Description": "Add a comment on how to setup your MVC controller in startup class.",
-              "ActionValidation": {
-                "Contains": "IApplicationBuilder.UseEndpoints(endpoints=>{endpoints.MapControllers();});",
                 "NotContains": "",
                 "CheckComments": "True"
               }


### PR DESCRIPTION
## Related issue

Closes: #118 


## Description
We currently do not support PathString and OpenIdConnect owin namespaces. We should add rules to port these APIs as well.

## Supplemental testing
All unit tests pass.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
