### PR TITLE
create unique report files

### DIFF
--- a/src/CTA.Rules.Config/Utils.cs
+++ b/src/CTA.Rules.Config/Utils.cs
@@ -131,5 +131,36 @@ namespace CTA.Rules.Config
 
             return destinationFile;
         }
+
+        /// <summary>
+        /// Generates a unique file name by appending the number of Ticks to the original file name.
+        /// A mutex is used so only 1 unique file name can be generated at a time, thus acting as
+        /// enough of a delay to ensure each filename is unique.
+        /// 
+        /// Note: 1 tick is 100 ns
+        /// </summary>
+        /// <param name="fileName">Original name of file</param>
+        /// <param name="extension">Extension to be appended to file name</param>
+        /// <param name="mutexName">Identifier name of mutex</param>
+        /// <param name="timeoutInSeconds">Time to wait for the mutex handle</param>
+        /// <returns>File name with unique tick identifier and file extension appended to it</returns>
+        public static string GenerateUniqueFileName(string fileName, string extension, string mutexName, int timeoutInSeconds = 5)
+        {
+            long now;
+            using Mutex mutex = new Mutex(false, mutexName);
+            if (mutex.WaitOne(timeoutInSeconds))
+            {
+                now = DateTime.Now.Ticks;
+                mutex.ReleaseMutex();
+            }
+            else
+            {
+                // Mutex is used as a delay so if mutex wait time has been exceeded,
+                // we can use current datetime anyway
+                now = DateTime.Now.Ticks;
+            }
+
+            return $"{fileName}_{now}.{extension}";
+        }
     }
 }

--- a/src/CTA.Rules.Metrics/PortSolutionResultReportGenerator.cs
+++ b/src/CTA.Rules.Metrics/PortSolutionResultReportGenerator.cs
@@ -11,6 +11,8 @@ namespace CTA.Rules.Metrics
 {
     public class PortSolutionResultReportGenerator
     {
+        private const string ReportGeneratorMutex = "ReportGeneratorMutex";
+
         public MetricsContext Context { get; set; }
         public PortSolutionResult PortSolutionResult { get; set; }
         public Dictionary<string, FeatureDetectionResult> FeatureDetectionResults { get; set; }
@@ -47,8 +49,10 @@ namespace CTA.Rules.Metrics
             GeneratePortSolutionResultJsonReport();
             GeneratePortSolutionResultTextReport();
 
-            ExportStringToFile(PortSolutionResult.SolutionPath, "PortSolutionResult.json", PortSolutionResultJsonReport);
-            ExportStringToFile(PortSolutionResult.SolutionPath, "PortSolutionResult.txt", PortSolutionResultTextReport);
+            var jsonReportFileName = Utils.GenerateUniqueFileName("PortSolutionResult", "json", ReportGeneratorMutex);
+            var textReportFileName = Utils.GenerateUniqueFileName("PortSolutionResult", "txt", ReportGeneratorMutex);
+            ExportStringToFile(PortSolutionResult.SolutionPath, jsonReportFileName, PortSolutionResultJsonReport);
+            ExportStringToFile(PortSolutionResult.SolutionPath, textReportFileName, PortSolutionResultTextReport);
         }
 
         public void GenerateAnalysisReport()
@@ -147,6 +151,7 @@ namespace CTA.Rules.Metrics
             {
                 var filePath = GetFilePath(projectOrSolutionPath, fileName);
                 File.WriteAllText(filePath, content);
+                
             }
             catch (Exception ex)
             {

--- a/src/CTA.Rules.Metrics/PortSolutionResultReportGenerator.cs
+++ b/src/CTA.Rules.Metrics/PortSolutionResultReportGenerator.cs
@@ -151,7 +151,6 @@ namespace CTA.Rules.Metrics
             {
                 var filePath = GetFilePath(projectOrSolutionPath, fileName);
                 File.WriteAllText(filePath, content);
-                
             }
             catch (Exception ex)
             {

--- a/src/CTA.Rules.Metrics/PortSolutionResultReportGenerator.cs
+++ b/src/CTA.Rules.Metrics/PortSolutionResultReportGenerator.cs
@@ -11,8 +11,6 @@ namespace CTA.Rules.Metrics
 {
     public class PortSolutionResultReportGenerator
     {
-        private const string ReportGeneratorMutex = "ReportGeneratorMutex";
-
         public MetricsContext Context { get; set; }
         public PortSolutionResult PortSolutionResult { get; set; }
         public Dictionary<string, FeatureDetectionResult> FeatureDetectionResults { get; set; }
@@ -48,11 +46,9 @@ namespace CTA.Rules.Metrics
             GenerateMetrics();
             GeneratePortSolutionResultJsonReport();
             GeneratePortSolutionResultTextReport();
-
-            var jsonReportFileName = Utils.GenerateUniqueFileName("PortSolutionResult", "json", ReportGeneratorMutex);
-            var textReportFileName = Utils.GenerateUniqueFileName("PortSolutionResult", "txt", ReportGeneratorMutex);
-            ExportStringToFile(PortSolutionResult.SolutionPath, jsonReportFileName, PortSolutionResultJsonReport);
-            ExportStringToFile(PortSolutionResult.SolutionPath, textReportFileName, PortSolutionResultTextReport);
+            
+            ExportStringToFile(PortSolutionResult.SolutionPath, "PortSolutionResult.json", PortSolutionResultJsonReport);
+            ExportStringToFile(PortSolutionResult.SolutionPath, "PortSolutionResult.txt", PortSolutionResultTextReport);
         }
 
         public void GenerateAnalysisReport()
@@ -150,7 +146,7 @@ namespace CTA.Rules.Metrics
             try
             {
                 var filePath = GetFilePath(projectOrSolutionPath, fileName);
-                File.WriteAllText(filePath, content);
+                Utils.ThreadSafeExportStringToFile(filePath, content);
             }
             catch (Exception ex)
             {

--- a/tst/CTA.Rules.Test/UtilsTest.cs
+++ b/tst/CTA.Rules.Test/UtilsTest.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using CTA.FeatureDetection.Common.Models.Configuration;
 using CTA.Rules.Config;
 using NUnit.Framework;
 using System.IO;
-using System.Net.NetworkInformation;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace CTA.Rules.Test
@@ -55,7 +52,7 @@ namespace CTA.Rules.Test
             var tasks = new List<Task>();
             var fileNames = new List<string>();
 
-            for (int i = 0; i < 10000; i++)
+            for (int i = 0; i < 100; i++)
             {
                 tasks.Add(Task.Run(() => {
                     fileNames.Add(Utils.GenerateUniqueFileName(fileName, extension, mutexName));
@@ -63,9 +60,28 @@ namespace CTA.Rules.Test
             }
             var t = Task.WhenAll(tasks);
             t.Wait();
-            
+
             Assert.True(t.Status == TaskStatus.RanToCompletion);
             CollectionAssert.AllItemsAreUnique(fileNames);
+        }
+
+        [Test]
+        public void ThreadSafeExportStringToFile_Permits_Concurrent_Processes()
+        {
+            var filePath = "test.txt";
+            var content = "Test file content";
+            var tasks = new List<Task>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                tasks.Add(Task.Run(() => {
+                    Utils.ThreadSafeExportStringToFile(filePath, content);
+                }));
+            }
+            var t = Task.WhenAll(tasks);
+            t.Wait();
+
+            Assert.True(t.Status == TaskStatus.RanToCompletion);
         }
     }
 }

--- a/tst/CTA.Rules.Test/UtilsTest.cs
+++ b/tst/CTA.Rules.Test/UtilsTest.cs
@@ -3,12 +3,34 @@ using CTA.FeatureDetection.Common.Models.Configuration;
 using CTA.Rules.Config;
 using NUnit.Framework;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace CTA.Rules.Test
 {
+    [TestFixture]
     public class UtilsTests : AwsRulesBaseTest
     {
+        private const string TempDir = nameof(UtilsTests);
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            if (!Directory.Exists(TempDir))
+            {
+                Directory.CreateDirectory(TempDir);
+            }
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            if (Directory.Exists(TempDir))
+            {
+                Directory.Delete(TempDir, true);
+            }
+        }
+
         [SetUp]
         public void Setup()
         {
@@ -46,8 +68,7 @@ namespace CTA.Rules.Test
         [Test]
         public void GenerateUniqueFileName_Maintains_Uniqueness_Across_Concurrent_Processes()
         {
-            var fileName = "MyFile";
-            var extension = "json";
+            var filePath = "MyFile.json";
             var mutexName = "mutex";
             var tasks = new List<Task>();
             var fileNames = new List<string>();
@@ -55,7 +76,7 @@ namespace CTA.Rules.Test
             for (int i = 0; i < 100; i++)
             {
                 tasks.Add(Task.Run(() => {
-                    fileNames.Add(Utils.GenerateUniqueFileName(fileName, extension, mutexName));
+                    fileNames.Add(Utils.GenerateUniqueFileName(filePath, mutexName));
                 }));
             }
             var t = Task.WhenAll(tasks);
@@ -68,20 +89,28 @@ namespace CTA.Rules.Test
         [Test]
         public void ThreadSafeExportStringToFile_Permits_Concurrent_Processes()
         {
-            var filePath = "test.txt";
+            var filePath = Path.Combine(TempDir, "test.txt");
             var content = "Test file content";
             var tasks = new List<Task>();
-
+            var filePaths = new List<string>();
             for (int i = 0; i < 10; i++)
             {
                 tasks.Add(Task.Run(() => {
-                    Utils.ThreadSafeExportStringToFile(filePath, content);
+                    var writtenFilePath = Utils.ThreadSafeExportStringToFile(filePath, content);
+                    filePaths.Add(writtenFilePath);
                 }));
             }
             var t = Task.WhenAll(tasks);
             t.Wait();
 
             Assert.True(t.Status == TaskStatus.RanToCompletion);
+
+            // Since concurrent file access is permitted, there should be no naming conflicts,
+            // and therefore no files should be renamed
+            Assert.True(filePaths.All(f => f.Equals(filePath)));
+
+            // Confirm that text was written to file
+            Assert.AreEqual(content, File.ReadAllText(filePath));
         }
     }
 }


### PR DESCRIPTION
## Related issue

Closes: #127


## Description
* Reports are written to unique file names using ticks as a modifier. This prevents file access errors if the processes share the same file or if the user has a previous report open.

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
