### PR TITLE
Fix test path too long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ publish/
 # Local directories
 .vshistory/
 tst/Projects/
+/tst/CopyFolder

--- a/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
+++ b/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
@@ -200,7 +200,7 @@ namespace CTA.Rules.Test
         {
             string solutionPath = Directory.EnumerateFiles(tempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault(s => !s.Contains(string.Concat(Path.DirectorySeparatorChar, CopyFolder, Path.DirectorySeparatorChar)));
             string solutionDir = Directory.GetParent(solutionPath).FullName;
-            var newTempDir = Path.Combine(Directory.GetParent(solutionDir).FullName, CopyFolder, Guid.NewGuid().ToString());
+            var newTempDir = Path.Combine(GetTstPath(this.GetType()), CopyFolder, Guid.NewGuid().ToString());
             CopyDirectory(new DirectoryInfo(solutionDir), new DirectoryInfo(newTempDir));
 
             solutionPath = Directory.EnumerateFiles(newTempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault();


### PR DESCRIPTION
## Related issue

Closes: #148 


## Description
Unit tests are failing on local machines but passing in the pipeline. It was discovered that this was caused by the folder path being too long.

## Supplemental testing
All unit test now pass.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
