### PR TITLE
ensure AnalysisRun() is executed before porting in Run()

### DIFF
--- a/tst/CTA.Rules.Test/PortCoreTests.cs
+++ b/tst/CTA.Rules.Test/PortCoreTests.cs
@@ -1,8 +1,5 @@
-using Codelyzer.Analysis;
 using CTA.Rules.PortCore;
-using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -286,11 +283,12 @@ namespace CTA.Rules.Test
             TestSolutionAnalysis results = AnalyzeSolution("AntlrSample.sln", tempDir, downloadLocation, version);
 
             // Verify new .csproj file exists
-            var addsAntlr3RuntimeProjectFile = results.ProjectResults.Where(p => p.CsProjectPath.EndsWith("Adds.Antlr3.Runtime.csproj")).FirstOrDefault();
+            var addsAntlr3RuntimeProjectFile = results.ProjectResults.First(p => p.CsProjectPath.EndsWith("Adds.Antlr3.Runtime.csproj"));
             FileAssert.Exists(addsAntlr3RuntimeProjectFile.CsProjectPath);
 
             // No build errors expected in the ported project
-            Assert.False(results.SolutionRunResult.BuildErrors[addsAntlr3RuntimeProjectFile.CsProjectPath].Any());
+            var buildErrors = GetSolutionBuildErrors(results.SolutionRunResult.SolutionPath);
+            Assert.AreEqual(0, buildErrors.Count);
 
             // Verify the new package has been added
             var csProjectContent = addsAntlr3RuntimeProjectFile.CsProjectContent;
@@ -396,11 +394,12 @@ namespace CTA.Rules.Test
             TestSolutionAnalysis results = AnalyzeSolution("IonicZipSample.sln", tempDir, downloadLocation, version);
 
             // Verify new .csproj file exists
-            var ionicZipProjectFile = results.ProjectResults.Where(p => p.CsProjectPath.EndsWith("IonicZipSample.csproj")).FirstOrDefault();
+            var ionicZipProjectFile = results.ProjectResults.First(p => p.CsProjectPath.EndsWith("IonicZipSample.csproj"));
             FileAssert.Exists(ionicZipProjectFile.CsProjectPath);
 
             // No build errors expected in the ported project
-            Assert.False(results.SolutionRunResult.BuildErrors[ionicZipProjectFile.CsProjectPath].Any());
+            var buildErrors = GetSolutionBuildErrors(results.SolutionRunResult.SolutionPath);
+            Assert.AreEqual(0, buildErrors.Count);
 
             // Verify the new package has been added
             var csProjectContent = ionicZipProjectFile.CsProjectContent;


### PR DESCRIPTION
## Related issue

Closes: #149


## Description
* Ensures AnalysisRun() will be called prior to porting execution in Run()

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
