### PR TITLE
Change NodeToken.Clone from shallow clone to deep clone

### DIFF
--- a/src/CTA.Rules.Models/Actions/Attributeaction.cs
+++ b/src/CTA.Rules.Models/Actions/Attributeaction.cs
@@ -8,7 +8,7 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, AttributeSyntax, AttributeSyntax> AttributeActionFunc { get; set; }
         public Func<SyntaxGenerator, AttributeListSyntax, AttributeListSyntax> AttributeListActionFunc { get; set; }
-
+        public new AttributeAction Clone() => (AttributeAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (AttributeAction)obj;

--- a/src/CTA.Rules.Models/Actions/Attributeaction.cs
+++ b/src/CTA.Rules.Models/Actions/Attributeaction.cs
@@ -8,7 +8,7 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, AttributeSyntax, AttributeSyntax> AttributeActionFunc { get; set; }
         public Func<SyntaxGenerator, AttributeListSyntax, AttributeListSyntax> AttributeListActionFunc { get; set; }
-        public new AttributeAction Clone() => (AttributeAction)this.MemberwiseClone();
+
         public override bool Equals(object obj)
         {
             var action = (AttributeAction)obj;

--- a/src/CTA.Rules.Models/Actions/Classdeclarationaction.cs
+++ b/src/CTA.Rules.Models/Actions/Classdeclarationaction.cs
@@ -9,6 +9,7 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, ClassDeclarationSyntax, ClassDeclarationSyntax> ClassDeclarationActionFunc { get; set; }
 
+        public new ClassDeclarationAction Clone() => (ClassDeclarationAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (ClassDeclarationAction)obj;

--- a/src/CTA.Rules.Models/Actions/Classdeclarationaction.cs
+++ b/src/CTA.Rules.Models/Actions/Classdeclarationaction.cs
@@ -9,7 +9,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, ClassDeclarationSyntax, ClassDeclarationSyntax> ClassDeclarationActionFunc { get; set; }
 
-        public new ClassDeclarationAction Clone() => (ClassDeclarationAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (ClassDeclarationAction)obj;

--- a/src/CTA.Rules.Models/Actions/Elementaccessaction.cs
+++ b/src/CTA.Rules.Models/Actions/Elementaccessaction.cs
@@ -8,6 +8,8 @@ namespace CTA.Rules.Models
     public class ElementAccessAction : GenericAction
     {
         public Func<SyntaxGenerator, ElementAccessExpressionSyntax, ElementAccessExpressionSyntax> ElementAccessExpressionActionFunc { get; set; }
+
+        public new ElementAccessAction Clone() => (ElementAccessAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (ElementAccessAction)obj;

--- a/src/CTA.Rules.Models/Actions/Elementaccessaction.cs
+++ b/src/CTA.Rules.Models/Actions/Elementaccessaction.cs
@@ -9,7 +9,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, ElementAccessExpressionSyntax, ElementAccessExpressionSyntax> ElementAccessExpressionActionFunc { get; set; }
 
-        public new ElementAccessAction Clone() => (ElementAccessAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (ElementAccessAction)obj;

--- a/src/CTA.Rules.Models/Actions/GenericAction.cs
+++ b/src/CTA.Rules.Models/Actions/GenericAction.cs
@@ -17,6 +17,6 @@ namespace CTA.Rules.Models
         public TextSpan TextSpan { get; set; }
         public ActionValidation ActionValidation { get; set; }
 
-        public GenericAction Clone() => (GenericAction)this.MemberwiseClone();
+        public T Clone<T>() => (T)this.MemberwiseClone();
     }
 }

--- a/src/CTA.Rules.Models/Actions/Identifiernameaction.cs
+++ b/src/CTA.Rules.Models/Actions/Identifiernameaction.cs
@@ -9,7 +9,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, IdentifierNameSyntax, IdentifierNameSyntax> IdentifierNameActionFunc { get; set; }
 
-        public new IdentifierNameAction Clone() => (IdentifierNameAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (IdentifierNameAction)obj;

--- a/src/CTA.Rules.Models/Actions/Identifiernameaction.cs
+++ b/src/CTA.Rules.Models/Actions/Identifiernameaction.cs
@@ -8,6 +8,8 @@ namespace CTA.Rules.Models
     public class IdentifierNameAction : GenericAction
     {
         public Func<SyntaxGenerator, IdentifierNameSyntax, IdentifierNameSyntax> IdentifierNameActionFunc { get; set; }
+
+        public new IdentifierNameAction Clone() => (IdentifierNameAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (IdentifierNameAction)obj;

--- a/src/CTA.Rules.Models/Actions/InterfaceDeclarationAction.cs
+++ b/src/CTA.Rules.Models/Actions/InterfaceDeclarationAction.cs
@@ -8,6 +8,7 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, InterfaceDeclarationSyntax, InterfaceDeclarationSyntax> InterfaceDeclarationActionFunc { get; set; }
 
+        public new InterfaceDeclarationAction Clone() => (InterfaceDeclarationAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (InterfaceDeclarationAction)obj;

--- a/src/CTA.Rules.Models/Actions/InterfaceDeclarationAction.cs
+++ b/src/CTA.Rules.Models/Actions/InterfaceDeclarationAction.cs
@@ -8,7 +8,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, InterfaceDeclarationSyntax, InterfaceDeclarationSyntax> InterfaceDeclarationActionFunc { get; set; }
 
-        public new InterfaceDeclarationAction Clone() => (InterfaceDeclarationAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (InterfaceDeclarationAction)obj;

--- a/src/CTA.Rules.Models/Actions/Invocationexpressionaction.cs
+++ b/src/CTA.Rules.Models/Actions/Invocationexpressionaction.cs
@@ -8,6 +8,8 @@ namespace CTA.Rules.Models
     public class InvocationExpressionAction : GenericAction
     {
         public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> InvocationExpressionActionFunc { get; set; }
+
+        public new InvocationExpressionAction Clone() => (InvocationExpressionAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (InvocationExpressionAction)obj;

--- a/src/CTA.Rules.Models/Actions/Invocationexpressionaction.cs
+++ b/src/CTA.Rules.Models/Actions/Invocationexpressionaction.cs
@@ -9,7 +9,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> InvocationExpressionActionFunc { get; set; }
 
-        public new InvocationExpressionAction Clone() => (InvocationExpressionAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (InvocationExpressionAction)obj;

--- a/src/CTA.Rules.Models/Actions/Memberaccessaction.cs
+++ b/src/CTA.Rules.Models/Actions/Memberaccessaction.cs
@@ -9,6 +9,8 @@ namespace CTA.Rules.Models
     public class MemberAccessAction : GenericAction
     {
         public Func<SyntaxGenerator, SyntaxNode, SyntaxNode> MemberAccessActionFunc { get; set; }
+
+        public new MemberAccessAction Clone() => (MemberAccessAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (MemberAccessAction)obj;

--- a/src/CTA.Rules.Models/Actions/Memberaccessaction.cs
+++ b/src/CTA.Rules.Models/Actions/Memberaccessaction.cs
@@ -10,7 +10,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, SyntaxNode, SyntaxNode> MemberAccessActionFunc { get; set; }
 
-        public new MemberAccessAction Clone() => (MemberAccessAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (MemberAccessAction)obj;

--- a/src/CTA.Rules.Models/Actions/MethodDeclarationAction.cs
+++ b/src/CTA.Rules.Models/Actions/MethodDeclarationAction.cs
@@ -8,6 +8,8 @@ namespace CTA.Rules.Models
     public class MethodDeclarationAction : GenericAction
     {
         public Func<SyntaxGenerator, MethodDeclarationSyntax, MethodDeclarationSyntax> MethodDeclarationActionFunc { get; set; }
+
+        public new MethodDeclarationAction Clone() => (MethodDeclarationAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (MethodDeclarationAction)obj;

--- a/src/CTA.Rules.Models/Actions/MethodDeclarationAction.cs
+++ b/src/CTA.Rules.Models/Actions/MethodDeclarationAction.cs
@@ -9,7 +9,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, MethodDeclarationSyntax, MethodDeclarationSyntax> MethodDeclarationActionFunc { get; set; }
 
-        public new MethodDeclarationAction Clone() => (MethodDeclarationAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (MethodDeclarationAction)obj;

--- a/src/CTA.Rules.Models/Actions/NamespaceAction.cs
+++ b/src/CTA.Rules.Models/Actions/NamespaceAction.cs
@@ -8,6 +8,8 @@ namespace CTA.Rules.Models
     public class NamespaceAction : GenericAction
     {
         public Func<SyntaxGenerator, NamespaceDeclarationSyntax, NamespaceDeclarationSyntax> NamespaceActionFunc { get; set; }
+
+        public new NamespaceAction Clone() => (NamespaceAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (NamespaceAction)obj;

--- a/src/CTA.Rules.Models/Actions/NamespaceAction.cs
+++ b/src/CTA.Rules.Models/Actions/NamespaceAction.cs
@@ -9,7 +9,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, NamespaceDeclarationSyntax, NamespaceDeclarationSyntax> NamespaceActionFunc { get; set; }
 
-        public new NamespaceAction Clone() => (NamespaceAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (NamespaceAction)obj;

--- a/src/CTA.Rules.Models/Actions/ObjectCreationExpressionAction.cs
+++ b/src/CTA.Rules.Models/Actions/ObjectCreationExpressionAction.cs
@@ -9,7 +9,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, ObjectCreationExpressionSyntax, ExpressionSyntax> ObjectCreationExpressionGenericActionFunc { get; set; }
 
-        public new ObjectCreationExpressionAction Clone() => (ObjectCreationExpressionAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (ObjectCreationExpressionAction)obj;

--- a/src/CTA.Rules.Models/Actions/ObjectCreationExpressionAction.cs
+++ b/src/CTA.Rules.Models/Actions/ObjectCreationExpressionAction.cs
@@ -8,6 +8,8 @@ namespace CTA.Rules.Models
     public class ObjectCreationExpressionAction : GenericAction
     {
         public Func<SyntaxGenerator, ObjectCreationExpressionSyntax, ExpressionSyntax> ObjectCreationExpressionGenericActionFunc { get; set; }
+
+        public new ObjectCreationExpressionAction Clone() => (ObjectCreationExpressionAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (ObjectCreationExpressionAction)obj;

--- a/src/CTA.Rules.Models/Actions/Packageaction.cs
+++ b/src/CTA.Rules.Models/Actions/Packageaction.cs
@@ -9,6 +9,8 @@ namespace CTA.Rules.Models
         public string OriginalVersion { get; set; }
         public string Version = "*";
         public TextSpan TextSpan { get; set; }
+
+        public PackageAction Clone() => (PackageAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (PackageAction)obj;

--- a/src/CTA.Rules.Models/Actions/ProjectLevelAction.cs
+++ b/src/CTA.Rules.Models/Actions/ProjectLevelAction.cs
@@ -7,6 +7,8 @@ namespace CTA.Rules.Models
     {
         public Func<string, ProjectType, string> ProjectLevelActionFunc { get; set; }
         public Func<string, ProjectType, List<string>, Dictionary<string, string>, List<string>, List<string>, string> ProjectFileActionFunc { get; set; }
+
+        public new ProjectLevelAction Clone() => (ProjectLevelAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (ProjectLevelAction)obj;

--- a/src/CTA.Rules.Models/Actions/ProjectLevelAction.cs
+++ b/src/CTA.Rules.Models/Actions/ProjectLevelAction.cs
@@ -8,7 +8,6 @@ namespace CTA.Rules.Models
         public Func<string, ProjectType, string> ProjectLevelActionFunc { get; set; }
         public Func<string, ProjectType, List<string>, Dictionary<string, string>, List<string>, List<string>, string> ProjectFileActionFunc { get; set; }
 
-        public new ProjectLevelAction Clone() => (ProjectLevelAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (ProjectLevelAction)obj;

--- a/src/CTA.Rules.Models/Actions/Usingaction.cs
+++ b/src/CTA.Rules.Models/Actions/Usingaction.cs
@@ -8,6 +8,8 @@ namespace CTA.Rules.Models
     public class UsingAction : GenericAction
     {
         public Func<SyntaxGenerator, CompilationUnitSyntax, CompilationUnitSyntax> UsingActionFunc { get; set; }
+
+        public new UsingAction Clone() => (UsingAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (UsingAction)obj;

--- a/src/CTA.Rules.Models/Actions/Usingaction.cs
+++ b/src/CTA.Rules.Models/Actions/Usingaction.cs
@@ -9,7 +9,6 @@ namespace CTA.Rules.Models
     {
         public Func<SyntaxGenerator, CompilationUnitSyntax, CompilationUnitSyntax> UsingActionFunc { get; set; }
 
-        public new UsingAction Clone() => (UsingAction)this.MemberwiseClone();
         public override bool Equals(object obj)
         {
             var action = (UsingAction)obj;

--- a/src/CTA.Rules.Models/TextChange.cs
+++ b/src/CTA.Rules.Models/TextChange.cs
@@ -8,6 +8,13 @@ namespace CTA.Rules.Models
         public string NewText { get; set; }
         public FileLinePositionSpan FileLinePositionSpan { get; set; }
 
+        public TextChange Clone() 
+        { 
+            TextChange cloned = (TextChange)this.MemberwiseClone();
+            cloned.FileLinePositionSpan = new FileLinePositionSpan(cloned.FileLinePositionSpan.Path, cloned.FileLinePositionSpan.Span);
+            return cloned;
+        }
+
         public bool Equals(TextChange textChange)
         {
             if (textChange == null) return false;

--- a/src/CTA.Rules.Models/Tokens/NodeToken.cs
+++ b/src/CTA.Rules.Models/Tokens/NodeToken.cs
@@ -55,23 +55,23 @@ namespace CTA.Rules.Models.Tokens
         public NodeToken Clone()
         {
             NodeToken cloned = (NodeToken)this.MemberwiseClone();
-            cloned.TextChanges = cloned.TextChanges.Select(textChange => textChange.Clone()).ToList();
-            cloned.TargetCPU = cloned.TargetCPU.ToList();
-            cloned.AttributeActions = cloned.AttributeActions.Select(action => action.Clone()).ToList();
-            cloned.AttributeListActions = cloned.AttributeListActions.Select(action => action.Clone()).ToList();
-            cloned.ClassDeclarationActions = cloned.ClassDeclarationActions.Select(action => action.Clone()).ToList();
-            cloned.InterfaceDeclarationActions = cloned.InterfaceDeclarationActions.Select(action => action.Clone()).ToList();
-            cloned.MethodDeclarationActions = cloned.MethodDeclarationActions.Select(action => action.Clone()).ToList();
-            cloned.ElementAccessActions = cloned.ElementAccessActions.Select(action => action.Clone()).ToList();
-            cloned.MemberAccessActions = cloned.MemberAccessActions.Select(action => action.Clone()).ToList();
-            cloned.UsingActions = cloned.UsingActions.Select(action => action.Clone()).ToList();
-            cloned.IdentifierNameActions = cloned.IdentifierNameActions.Select(action => action.Clone()).ToList();
-            cloned.InvocationExpressionActions = cloned.InvocationExpressionActions.Select(action => action.Clone()).ToList();
-            cloned.NamespaceActions = cloned.NamespaceActions.Select(action => action.Clone()).ToList();
-            cloned.ObjectCreationExpressionActions = cloned.ObjectCreationExpressionActions.Select(action => action.Clone()).ToList();
+            cloned.TextChanges = cloned.TextChanges?.Select(textChange => textChange.Clone()).ToList();
+            cloned.TargetCPU = cloned.TargetCPU?.ToList();
+            cloned.AttributeActions = cloned.AttributeActions?.Select(action => action.Clone<AttributeAction>())?.ToList();
+            cloned.AttributeListActions = cloned.AttributeListActions?.Select(action => action.Clone<AttributeAction>())?.ToList();
+            cloned.ClassDeclarationActions = cloned.ClassDeclarationActions?.Select(action => action.Clone<ClassDeclarationAction>())?.ToList();
+            cloned.InterfaceDeclarationActions = cloned.InterfaceDeclarationActions.Select(action => action.Clone<InterfaceDeclarationAction>()).ToList();
+            cloned.MethodDeclarationActions = cloned.MethodDeclarationActions.Select(action => action.Clone<MethodDeclarationAction>()).ToList();
+            cloned.ElementAccessActions = cloned.ElementAccessActions.Select(action => action.Clone<ElementAccessAction>()).ToList();
+            cloned.MemberAccessActions = cloned.MemberAccessActions.Select(action => action.Clone<MemberAccessAction>()).ToList();
+            cloned.UsingActions = cloned.UsingActions.Select(action => action.Clone<UsingAction>()).ToList();
+            cloned.IdentifierNameActions = cloned.IdentifierNameActions.Select(action => action.Clone<IdentifierNameAction>()).ToList();
+            cloned.InvocationExpressionActions = cloned.InvocationExpressionActions.Select(action => action.Clone<InvocationExpressionAction>()).ToList();
+            cloned.NamespaceActions = cloned.NamespaceActions.Select(action => action.Clone<NamespaceAction>()).ToList();
+            cloned.ObjectCreationExpressionActions = cloned.ObjectCreationExpressionActions.Select(action => action.Clone<ObjectCreationExpressionAction>()).ToList();
             cloned.PackageActions = cloned.PackageActions.Select(action => action.Clone()).ToList();
-            cloned.ProjectLevelActions = cloned.ProjectLevelActions.Select(action => action.Clone()).ToList();
-            cloned.ProjectFileActions = cloned.ProjectFileActions.Select(action => action.Clone()).ToList();
+            cloned.ProjectLevelActions = cloned.ProjectLevelActions.Select(action => action.Clone<ProjectLevelAction>()).ToList();
+            cloned.ProjectFileActions = cloned.ProjectFileActions.Select(action => action.Clone<ProjectLevelAction>()).ToList();
             return cloned;
         }
 

--- a/src/CTA.Rules.Models/Tokens/NodeToken.cs
+++ b/src/CTA.Rules.Models/Tokens/NodeToken.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+﻿using System.Linq;
 using System.Collections.Generic;
 using CTA.Rules.Config;
 using TextSpan = Codelyzer.Analysis.Model.TextSpan;
@@ -52,7 +52,28 @@ namespace CTA.Rules.Models.Tokens
         public List<ProjectLevelAction> ProjectLevelActions { get; set; }
         public List<ProjectLevelAction> ProjectFileActions { get; set; }
 
-        public NodeToken Clone() => (NodeToken)this.MemberwiseClone();
+        public NodeToken Clone()
+        {
+            NodeToken cloned = (NodeToken)this.MemberwiseClone();
+            cloned.TextChanges = cloned.TextChanges.Select(textChange => textChange.Clone()).ToList();
+            cloned.TargetCPU = cloned.TargetCPU.ToList();
+            cloned.AttributeActions = cloned.AttributeActions.Select(action => action.Clone()).ToList();
+            cloned.AttributeListActions = cloned.AttributeListActions.Select(action => action.Clone()).ToList();
+            cloned.ClassDeclarationActions = cloned.ClassDeclarationActions.Select(action => action.Clone()).ToList();
+            cloned.InterfaceDeclarationActions = cloned.InterfaceDeclarationActions.Select(action => action.Clone()).ToList();
+            cloned.MethodDeclarationActions = cloned.MethodDeclarationActions.Select(action => action.Clone()).ToList();
+            cloned.ElementAccessActions = cloned.ElementAccessActions.Select(action => action.Clone()).ToList();
+            cloned.MemberAccessActions = cloned.MemberAccessActions.Select(action => action.Clone()).ToList();
+            cloned.UsingActions = cloned.UsingActions.Select(action => action.Clone()).ToList();
+            cloned.IdentifierNameActions = cloned.IdentifierNameActions.Select(action => action.Clone()).ToList();
+            cloned.InvocationExpressionActions = cloned.InvocationExpressionActions.Select(action => action.Clone()).ToList();
+            cloned.NamespaceActions = cloned.NamespaceActions.Select(action => action.Clone()).ToList();
+            cloned.ObjectCreationExpressionActions = cloned.ObjectCreationExpressionActions.Select(action => action.Clone()).ToList();
+            cloned.PackageActions = cloned.PackageActions.Select(action => action.Clone()).ToList();
+            cloned.ProjectLevelActions = cloned.ProjectLevelActions.Select(action => action.Clone()).ToList();
+            cloned.ProjectFileActions = cloned.ProjectFileActions.Select(action => action.Clone()).ToList();
+            return cloned;
+        }
 
         public List<GenericAction> AllActions
         {

--- a/tst/CTA.Rules.Test/Actions/AttributeActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/AttributeActionsTests.cs
@@ -46,7 +46,7 @@ namespace CTA.Rules.Test.Actions
                 AttributeActionFunc = _attributeActions.GetChangeAttributeAction("NewAttribute")
             };
 
-            var cloned = attributeAction.Clone();
+            var cloned = attributeAction.Clone<AttributeAction>();
 
             Assert.True(attributeAction.Equals(cloned));
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/Actions/AttributeListActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/AttributeListActionsTests.cs
@@ -46,7 +46,7 @@ namespace CTA.Rules.Test.Actions
                 AttributeListActionFunc = _attributeListActions.GetAddCommentAction("NewAttribute")
             };
 
-            var cloned = attributeAction.Clone();
+            var cloned = attributeAction.Clone<AttributeAction>();
 
             Assert.True(attributeAction.Equals(cloned));
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/Actions/ClassActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/ClassActionsTests.cs
@@ -179,7 +179,7 @@ class MyClass
         public void ClassDeclarationEquals()
         {
             var classAction = new ClassDeclarationAction() { Key = "Test", Value = "Test2", ClassDeclarationActionFunc = _classActions.GetAddAttributeAction("Test") };
-            var cloned = classAction.Clone();
+            var cloned = classAction.Clone<ClassDeclarationAction>();
             Assert.True(classAction.Equals(cloned));
 
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/Actions/ElementAccessActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/ElementAccessActionsTests.cs
@@ -45,7 +45,7 @@ namespace CTA.Rules.Test.Actions
 
             };
 
-            var cloned = elementAccessAction.Clone();
+            var cloned = elementAccessAction.Clone<ElementAccessAction>();
 
             Assert.True(elementAccessAction.Equals(cloned));
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/Actions/InterfaceActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/InterfaceActionsTests.cs
@@ -57,7 +57,7 @@ interface ISomeInterface
         public void InterfaceDeclarationEquals()
         {
             var interfaceAction = new InterfaceDeclarationAction() { Key = "Test", Value = "Test2", InterfaceDeclarationActionFunc = _interfaceActions.GetAddAttributeAction("Test") };
-            var cloned = interfaceAction.Clone();
+            var cloned = interfaceAction.Clone<InterfaceDeclarationAction>();
             Assert.True(interfaceAction.Equals(cloned));
 
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/Actions/InvocationExpressionActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/InvocationExpressionActionsTests.cs
@@ -91,7 +91,7 @@ namespace CTA.Rules.Test.Actions
         public void InvocationExpressionEquals()
         {
             var invocationExpressionAction = new InvocationExpressionAction() { Key = "Test", Value = "Test2", InvocationExpressionActionFunc = _invocationExpressionActions.GetAddCommentAction("Test") };
-            var cloned = invocationExpressionAction.Clone();
+            var cloned = invocationExpressionAction.Clone<InvocationExpressionAction>();
             Assert.True(invocationExpressionAction.Equals(cloned));
 
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/Actions/MemberAccessActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/MemberAccessActionsTests.cs
@@ -44,7 +44,7 @@ namespace CTA.Rules.Test.Actions
                 MemberAccessActionFunc = _memberAccessActions.GetAddCommentAction("NewAttribute")
             };
 
-            var cloned = memberAccessAction.Clone();
+            var cloned = memberAccessAction.Clone<MemberAccessAction>();
 
             Assert.True(memberAccessAction.Equals(cloned));
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/Actions/MethodDeclarationActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/MethodDeclarationActionsTests.cs
@@ -61,7 +61,7 @@ namespace CTA.Rules.Test.Actions
                 MethodDeclarationActionFunc = _methodDeclarationActions.GetAddCommentAction("NewAttribute")
             };
 
-            var cloned = methodDeclarationAction.Clone();
+            var cloned = methodDeclarationAction.Clone<MethodDeclarationAction>();
 
             Assert.True(methodDeclarationAction.Equals(cloned));
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/Actions/ObjectCreationExpressionActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/ObjectCreationExpressionActionsTests.cs
@@ -51,7 +51,7 @@ namespace CTA.Rules.Test.Actions
         public void ObjectCreationExpressionActionEquals()
         {
             var objectCreationExpressionAction = new ObjectCreationExpressionAction() { Key = "Test", Value = "Test2", ObjectCreationExpressionGenericActionFunc = _objectCreationExpressionActions.GetReplaceObjectinitializationAction("Test") };
-            var cloned = objectCreationExpressionAction.Clone();
+            var cloned = objectCreationExpressionAction.Clone<ObjectCreationExpressionAction>();
             Assert.True(objectCreationExpressionAction.Equals(cloned));
 
             cloned.Value = "DifferentValue";
@@ -145,7 +145,7 @@ namespace CTA.Rules.Test.Actions
         public void ObjectCreationExpressionEquals()
         {
             var objectCreationExpressionAction = new ObjectCreationExpressionAction() { Key = "Test", Value = "Test2", ObjectCreationExpressionGenericActionFunc = _objectCreationExpressionActions.GetAddCommentAction("Test") };
-            var cloned = objectCreationExpressionAction.Clone();
+            var cloned = objectCreationExpressionAction.Clone<ObjectCreationExpressionAction>();
             Assert.True(objectCreationExpressionAction.Equals(cloned));
 
             cloned.Value = "DifferentValue";

--- a/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
+++ b/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
@@ -62,9 +62,16 @@ namespace CTA.Rules.Test
             return Path.Combine(srcPath, path);
         }
 
-        public TestSolutionAnalysis AnalyzeSolution(string solutionName, string tempDir, string downloadLocation, string version, Dictionary<string, List<string>> metaReferences = null, 
-            bool skipCopy = false, bool portCode = true)
-        {         
+        public TestSolutionAnalysis AnalyzeSolution(
+            string solutionName,
+            string tempDir,
+            string downloadLocation,
+            string version,
+            Dictionary<string, List<string>> metaReferences = null,
+            bool skipCopy = false,
+            bool portCode = true,
+            bool portProject = true)
+        {
             string solutionPath = Directory.EnumerateFiles(tempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault();
 
             if (!skipCopy)
@@ -72,10 +79,16 @@ namespace CTA.Rules.Test
                 solutionPath = CopySolutionFolderToTemp(solutionName, downloadLocation);
             }
 
-            return AnalyzeSolution(solutionPath, version, metaReferences, true, portCode);
+            return AnalyzeSolution(solutionPath, version, metaReferences, true, portCode, portProject);
         }
 
-        public TestSolutionAnalysis AnalyzeSolution(string solutionPath, string version, Dictionary<string, List<string>> metaReferences = null, bool skipCopy = false, bool portCode = true)
+        public TestSolutionAnalysis AnalyzeSolution(
+            string solutionPath,
+            string version,
+            Dictionary<string, List<string>> metaReferences = null,
+            bool skipCopy = false,
+            bool portCode = true,
+            bool portProject = true)
         {
             TestSolutionAnalysis result = new TestSolutionAnalysis();
             var solutionDir = Directory.GetParent(solutionPath).FullName;
@@ -101,7 +114,8 @@ namespace CTA.Rules.Test
                             UseDefaultRules = true,
                             TargetVersions = new List<string> { version },
                             PackageReferences = packages,
-                            PortCode = portCode
+                            PortCode = portCode,
+                            PortProject = portProject
                         };
 
                         if (metaReferences != null)

--- a/tst/CTA.Rules.Test/PortCoreTests.cs
+++ b/tst/CTA.Rules.Test/PortCoreTests.cs
@@ -1,5 +1,6 @@
 using CTA.Rules.PortCore;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -213,6 +214,65 @@ namespace CTA.Rules.Test
             TestSolutionAnalysis results = AnalyzeSolution(solutionPath, version, metaReferences, true);
 
             ValidateMvcMusicStore(results, version);
+        }
+
+        [TestCase(TargetFramework.Dotnet5)]
+        [TestCase(TargetFramework.DotnetCoreApp31)]
+        public void TestMvcMusicStoreWithoutProjectPort(string version)
+        {
+            var solutionPath = CopySolutionFolderToTemp("MvcMusicStore.sln", tempDir);
+            var analyzerResults = GenerateSolutionAnalysis(solutionPath);
+
+            var metaReferences = analyzerResults.ToDictionary(a => a.ProjectResult.ProjectFilePath, a => a.ProjectBuildResult.Project.MetadataReferences.Select(m => m.Display).ToList());
+            TestSolutionAnalysis results = AnalyzeSolution(solutionPath, version, metaReferences, true, false, false);
+
+            ValidateMvcMusicStoreSolutionRunResultNodeTokenDeepClone(results);
+        }
+
+        private void ValidateMvcMusicStoreSolutionRunResultNodeTokenDeepClone(TestSolutionAnalysis results)
+        {
+            var fileActions = results.SolutionRunResult.ProjectResults.FirstOrDefault().ProjectActions.FileActions;
+            // Before we change NodeToken Clone from shallow clone to deep
+            // clone, all the items in FileActions list refers to the same
+            // NodeToken object of a specific type, any TextChange object
+            // being added to the NodeToken.TextChanges list through one
+            // NodeToken reference in a FileAction object gets propogated
+            // to all the other NodeToken references retained by other
+            // FileAction objects. Thats why we were seeing 11 * 2 = 22
+            // TextChange objects in each FileAction.NodeTokens.TextChanges
+            // for this test project. Where:
+            // 
+            // 11 is the count of FileAction list
+            // 2 is the count of TextChanges each FileAction.NodeTokens has
+            // 
+            // After updating the Clone method to deep clone, we are seeing
+            // 2 TextChange objects in each FileAction.NodeTokens.TextChanges
+            // list, which is correct and expected.
+            var expectedNodeTokenTextChangesCounts = new Dictionary<string ,int>()
+            {
+                ["Global.asax.cs"] = 2,
+                ["CheckoutController.cs"] = 2,
+                ["HomeController.cs"] = 2,
+                ["AccountController.cs"] = 2,
+                ["StoreController.cs"] = 2,
+                ["StoreManagerController.cs"] = 2,
+                ["AccountModels.cs"] = 2,
+                ["Album.cs"] = 2,
+                ["MusicStoreEntities.cs"] = 2,
+                ["ShoppingCartController.cs"] = 2,
+                ["Order.cs"] = 2,
+                ["ShoppingCart.cs"] = 2,
+            };
+            expectedNodeTokenTextChangesCounts.ToList().ForEach(
+                expected =>
+                {
+                    Assert.AreEqual(
+                        expected.Value, 
+                        fileActions.FirstOrDefault(
+                            action => action.FilePath.Contains(expected.Key))
+                        .NodeTokens.First().TextChanges.Count);
+                }
+            );
         }
 
         private void ValidateMvcMusicStore(TestSolutionAnalysis results, string version)


### PR DESCRIPTION
## Related issue

Closes: #ISSUE_NUMBER_HERE


## Description
    With shallow clone, the cloned NodeToken object maintains a reference to
    the original NodeToken object's mutable variables. Any changes made to the
    original object's variables are reflected to the cloned ones. Eg.
    TextChanges variable of type List<TextChange> is a member of NodeToken
    class, with shallow clone, we observed the
    `ProjectResult.ProjectActions.FileActions` returned by
    `SolutionPort.Run()` has their `FileAction.NodeToken` field points to
    the same list of `TextChange` resulting duplicated results. Changing the
    clone to deep clone solves the issue.


## Supplemental testing
   Added test for to validate NodeToken deep clone.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
