### PR TITLE
prevent validating actions that have errored.

### DIFF
--- a/src/CTA.Rules.Update/CodeReplacer.cs
+++ b/src/CTA.Rules.Update/CodeReplacer.cs
@@ -275,9 +275,6 @@ namespace CTA.Rules.Update
                 {
                     var actionValidationException = new ActionValidationException(action.Key, action.Name);
                     action.InvalidExecutions = 1;
-                    var originalAction = actions.FirstOrDefault(a => a.GetHashCode() == action.GetHashCode());
-                    if(originalAction != null) 
-                        originalAction.InvalidExecutions = 1;
                     LogHelper.LogError(actionValidationException);
                 }
             }

--- a/src/CTA.Rules.Update/CodeReplacer.cs
+++ b/src/CTA.Rules.Update/CodeReplacer.cs
@@ -106,6 +106,7 @@ namespace CTA.Rules.Update
                 throw new FilePortingException(sourceFileBuildResult.SourceFilePath, new Exception("File already exists in collection"));
             }
         }
+
         private void GenerateCodeChanges(SyntaxNode root, SourceFileBuildResult sourceFileBuildResult, FileActions currentFileActions, int fileActionsCount, ConcurrentDictionary<string, List<GenericActionExecution>> actionsPerProject)
         {
             if (currentFileActions != null)
@@ -234,7 +235,10 @@ namespace CTA.Rules.Update
             // Matches all types of comments and strings
             //string regComments = @"\/\*(?:(?!\*\/)(?:.|[\r\n]+))*\*\/|\/\/(.*?)\r?\n|""((\\[^\n]|[^""\n])*)""|@(""[^""""]*"")+";
 
-            foreach (var action in actions)
+            //We should only validate actions that did not throw an exception during execution.
+            var validActions = actions.Where(a => a.InvalidExecutions == 0).ToList();
+
+            foreach (var action in validActions)
             {
                 var actionValidation = action.ActionValidation;
                 string trimmedResult = "";
@@ -271,6 +275,9 @@ namespace CTA.Rules.Update
                 {
                     var actionValidationException = new ActionValidationException(action.Key, action.Name);
                     action.InvalidExecutions = 1;
+                    var originalAction = actions.FirstOrDefault(a => a.GetHashCode() == action.GetHashCode());
+                    if(originalAction != null) 
+                        originalAction.InvalidExecutions = 1;
                     LogHelper.LogError(actionValidationException);
                 }
             }


### PR DESCRIPTION
## Related issue

Closes: #168 


## Description
If the solution fails to port due to various reasons we are still validating the results which creates a spike of false validation errors.

## Supplemental testing
All unit test pass, plus localized testing for ensuring logic works as intended.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
