### PR TITLE
overwrite files when exporting strings

### DIFF
--- a/src/CTA.Rules.Config/Utils.cs
+++ b/src/CTA.Rules.Config/Utils.cs
@@ -170,7 +170,7 @@ namespace CTA.Rules.Config
         {
             try
             {
-                using var fileStream = File.Open(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, fileShare);
+                using var fileStream = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite, fileShare);
                 using var streamWriter = new StreamWriter(fileStream);
                 streamWriter.Write(content);
 
@@ -183,7 +183,7 @@ namespace CTA.Rules.Config
                 // and try writing again.
                 var uniqueFileName = GenerateUniqueFileName(filePath, mutexName);
                 
-                using var fileStream = File.Open(uniqueFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, fileShare);
+                using var fileStream = File.Open(uniqueFileName, FileMode.Create, FileAccess.ReadWrite, fileShare);
                 using var streamWriter = new StreamWriter(fileStream);
                 streamWriter.Write(content);
 


### PR DESCRIPTION
## Related issue

Closes: #177


## Description
* Fixes issue where generated reports are not fully overwritten by new reports.

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
