### PR TITLE
Skip overriding rules when user provided ruleDir is the same as defaultRuleDir

### DIFF
--- a/src/CTA.Rules.PortCore/SolutionPort.cs
+++ b/src/CTA.Rules.PortCore/SolutionPort.cs
@@ -328,6 +328,10 @@ namespace CTA.Rules.PortCore
 
         internal void CopyOverrideRules(string sourceDir)
         {
+            // Skip overriding the same directory.
+            if(sourceDir == Constants.RulesDefaultPath) { 
+                return; 
+            }
             var files = Directory.EnumerateFiles(sourceDir, "*.json").ToList();
             files.ForEach(file => {
                 File.Copy(file, Path.Combine(Constants.RulesDefaultPath, Path.GetFileName(file)), true);


### PR DESCRIPTION
`CopyOverrideRules` throws `IOException` with message: `"The process cannot
access the file 'file path' because it is being used by another process"` when the input ruleDir is set to the same as defaultRuleDir.

The error can be reproduced by running PortCore cli twice with `--use-builtin-rules` set to `True`.

## Related issue

Closes: #184 


## Description
* Describe the changes in this pull request

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
