### PR TITLE
New rules for AuthenticationTicket and ISecureDataFormat

### DIFF
--- a/src/CTA.Rules.Analysis/RulesAnalysis.cs
+++ b/src/CTA.Rules.Analysis/RulesAnalysis.cs
@@ -234,6 +234,16 @@ namespace CTA.Rules.Analyzer
                                             overrideKey = compareToken.Key;
                                         }
                                     }
+                                    //If the semanticClassType is too specific to apply to all TData types
+                                    if(token == null)
+                                    {
+                                        if(invocationExpression.SemanticClassType.Contains('<'))
+                                        {
+                                            string semanticClassType = invocationExpression.SemanticClassType.Substring(0,invocationExpression.SemanticClassType.IndexOf('<'));
+                                            compareToken = new InvocationExpressionToken() { Key = invocationExpression.SemanticOriginalDefinition, Namespace = invocationExpression.Reference.Namespace, Type = semanticClassType };
+                                            _rootNodes.Invocationexpressiontokens.TryGetValue(compareToken, out token);
+                                        }
+                                    }
                                 }
 
                                 if (token != null)

--- a/tst/CTA.Rules.Test/Models/ExpectedOutputConstants.cs
+++ b/tst/CTA.Rules.Test/Models/ExpectedOutputConstants.cs
@@ -12,6 +12,7 @@ using System;
 using System.Web;
 using System.Security.Claims;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Owin;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -39,9 +40,10 @@ namespace AspNetRoutes
             return context.Response.WriteAsync(""Hello World "" + check);
         }
 
-        public async Task<bool> SignUpUser(HttpContext authenticationManager)
+        public async Task<bool> SignUpUser(HttpContext authenticationManager, ISecureDataFormat<AuthenticationTicket> df)
         {
-            List<ClaimsIdentity> claims = new List<ClaimsIdentity>();
+            List<ClaimsIdentity> claims = new List<ClaimsIdentity>()
+            {new ClaimsIdentity()};
             AuthenticationProperties authProp = new AuthenticationProperties();
             var authResult = await authenticationManager.AuthenticateAsync("""");
             /* Added by CTA: Please use your AuthenticationProperties object with this ChallengeAsync api if needed. You can also include a scheme. */
@@ -56,7 +58,11 @@ namespace AspNetRoutes
             await authenticationManager.SignInAsync(claims.ToArray());
             /* Added by CTA: You can only pass in a single scheme as a parameter and you can also include an AuthenticationProperties object as well. */
             await authenticationManager.SignOutAsync();
-            return true;
+            AuthenticationTicket at = /* Added by CTA: Please use a ClaimsPrincipal object to wrap your ClaimsIdentity parameter to pass to this method, you can optionally include an AuthenticationProperties object and must include a scheme. */
+            new AuthenticationTicket(claims.First(), authProp);
+            string prot = df.Protect(at);
+            AuthenticationTicket unProtectedAT = df.Unprotect(prot);
+            return at.Equals(unProtectedAT);
         }
     }
 }";

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.json
@@ -747,6 +747,161 @@
           ]
         }
       ]
+    },
+    {
+      "Type": "Class",
+      "Name": "Microsoft.Owin.Security.AuthenticationTicket",
+      "Value": "Microsoft.Owin.Security.AuthenticationTicket",
+      "KeyType": "Identifier",
+      "ContainingType": "Microsoft.Owin.Security",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.AuthenticationTicket add directive Microsoft.AspNetCore.Authentication.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.Security.AuthenticationTicket.AuthenticationTicket(System.Security.Claims.ClaimsIdentity, Microsoft.Owin.Security.AuthenticationProperties)",
+      "Value": "Microsoft.Owin.Security.AuthenticationTicket.AuthenticationTicket(System.Security.Claims.ClaimsIdentity, Microsoft.Owin.Security.AuthenticationProperties)",
+      "KeyType": "Name",
+      "ContainingType": "AuthenticationTicket",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.AuthenticationTicket.AuthenticationTicket(System.Security.Claims.ClaimsIdentity, Microsoft.Owin.Security.AuthenticationProperties) add directive Microsoft.AspNetCore.Authentication, add a comment to explain the new parameters requirements.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "Please use a ClaimsPrincipal object to wrap your ClaimsIdentity parameter to pass to this method, you can optionally include an AuthenticationProperties object and must include a scheme.",
+              "Description": "Add a comment to explain how to use the parameters for the AuthenticationTicket constructor.",
+              "ActionValidation": {
+                "Contains": "Please use a ClaimsPrincipal object to wrap your list of ClaimsIdentity to pass it to this method as a parameter, you can also include an AuthenticationProperties object and a scheme as well.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.ISecureDataFormat<TData>.Protect(TData)",
+      "Value": "Microsoft.Owin.Security.ISecureDataFormat<TData>.Protect(TData)",
+      "KeyType": "",
+      "ContainingType": "ISecureDataFormat",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.ISecureDataFormat<TData>.Protect(TData) add directive Microsoft.AspNetCore.Authentication.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.ISecureDataFormat<TData>.Unprotect(string)",
+      "Value": "Microsoft.Owin.Security.ISecureDataFormat<TData>.Unprotect(string)",
+      "KeyType": "",
+      "ContainingType": "ISecureDataFormat",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.ISecureDataFormat<TData>.Unprotect(string) add directive Microsoft.AspNetCore.Authentication.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Related issue

Closes: #191 


## Description
Currently we lack porting rules for Microsoft.Owin.Security. AuthenticationTicket and ISecureDataFormat.
Also found a weakness in InvocationExpression token comparison which doesn't account for TData types for semantic class types, added extra code to allow for multiple data types support.

## Supplemental testing
All unit tests pass.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
