### PR TITLE
Add MissingMetaReference to CTA metrics.

### DIFF
--- a/src/CTA.FeatureDetection.Common/CTA.FeatureDetection.Common.csproj
+++ b/src/CTA.FeatureDetection.Common/CTA.FeatureDetection.Common.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Codelyzer.Analysis" Version="1.6.8-alpha-g34252ac19a" />
+    <PackageReference Include="Codelyzer.Analysis" Version="1.6.18-alpha-gb5c231484b" />
   </ItemGroup>
   
   <ItemGroup>    

--- a/src/CTA.Rules.Metrics/MetricsTransformer.cs
+++ b/src/CTA.Rules.Metrics/MetricsTransformer.cs
@@ -108,6 +108,19 @@ namespace CTA.Rules.Metrics
             return referencesMetrics;
         }
 
+        internal static IEnumerable<MissingMetaReferenceMetric> TransformMissingMetaReferences(MetricsContext context, ProjectResult projectResult)
+        {
+            var projectFile = projectResult.ProjectFile;
+            var missingMetaReferences = projectResult.MissingMetaReferences;
+            var missingMetaReferenceMetrics = new List<MissingMetaReferenceMetric>();
+            foreach (var reference in missingMetaReferences)
+            {
+                missingMetaReferenceMetrics.Add(new MissingMetaReferenceMetric(context, reference, projectFile));
+            }
+
+            return missingMetaReferenceMetrics;
+        }
+
         internal static IEnumerable<BuildErrorMetric> TransformBuildErrors(MetricsContext context,
             Dictionary<string, Dictionary<string, int>> buildErrorsByProject)
         {

--- a/src/CTA.Rules.Metrics/Models/MissingMetaReferenceMetric.cs
+++ b/src/CTA.Rules.Metrics/Models/MissingMetaReferenceMetric.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace CTA.Rules.Metrics
+{
+    public class MissingMetaReferenceMetric : CTAMetric
+    {
+        [JsonProperty("metricName", Order = 10)]
+        public string MetricName => "MissingMetaReference";
+
+        [JsonProperty("metaReference", Order = 11)]
+        public string MetaReference { get; set; }
+
+        [JsonProperty("solutionPath", Order = 30)]
+        public string SolutionPathHash { get; set; }
+
+        [JsonProperty("projectGuid", Order = 40)]
+        public string ProjectGuid { get; set; }
+
+        public MissingMetaReferenceMetric(MetricsContext context, string metaReference, string projectPath)
+        {
+            MetaReference = metaReference;
+            SolutionPathHash = context.SolutionPathHash;
+            ProjectGuid = context.ProjectGuidMap.GetValueOrDefault(projectPath, "N/A");
+        }
+    }
+}

--- a/src/CTA.Rules.Metrics/PortSolutionResultReportGenerator.cs
+++ b/src/CTA.Rules.Metrics/PortSolutionResultReportGenerator.cs
@@ -15,6 +15,7 @@ namespace CTA.Rules.Metrics
         public PortSolutionResult PortSolutionResult { get; set; }
         public Dictionary<string, FeatureDetectionResult> FeatureDetectionResults { get; set; }
         public IEnumerable<ReferencesMetric> ReferencesMetrics { get; set; }
+        public IEnumerable<MissingMetaReferenceMetric> MissingMetaReferenceMetrics { get; set; }
         public IEnumerable<DownloadedFilesMetric> DownloadedFilesMetrics { get; set; }
         public IEnumerable<TargetVersionMetric> TargetVersionMetrics { get; set; }
         public IEnumerable<UpgradePackageMetric> UpgradePackageMetrics { get; set; }
@@ -63,12 +64,14 @@ namespace CTA.Rules.Metrics
             var actionPackageMetrics = new List<ActionPackageMetric>();
             var actionMetrics = new List<GenericActionMetric>();
             var featureDetectionMetrics = new List<FeatureDetectionMetric>();
+            var missingMetaReferenceMetrics = new List<MissingMetaReferenceMetric>();
 
             foreach (var projectResult in PortSolutionResult.ProjectResults)
             {
                 upgradePackageMetrics.AddRange(MetricsTransformer.TransformUpgradePackages(Context, projectResult));
                 actionPackageMetrics.AddRange(MetricsTransformer.TransformActionPackages(Context, projectResult));
                 actionMetrics.AddRange(MetricsTransformer.TransformProjectActions(Context, projectResult));
+                missingMetaReferenceMetrics.AddRange(MetricsTransformer.TransformMissingMetaReferences(Context, projectResult));
             }
             featureDetectionMetrics.AddRange(MetricsTransformer.TransformFeatureDetectionResults(Context, FeatureDetectionResults));
 
@@ -76,6 +79,7 @@ namespace CTA.Rules.Metrics
             ActionPackageMetrics = actionPackageMetrics;
             GenericActionMetrics = actionMetrics;
             FeatureDetectionMetrics = featureDetectionMetrics;
+            MissingMetaReferenceMetrics = missingMetaReferenceMetrics;
         }
 
         private void GenerateMetrics()
@@ -90,6 +94,7 @@ namespace CTA.Rules.Metrics
             var upgradePackageMetrics = new List<UpgradePackageMetric>();
             var actionPackageMetrics = new List<ActionPackageMetric>();
             var actionExecutionMetrics = new List<GenericActionExecutionMetric>();
+            var missingMetaReferenceMetrics = new List<MissingMetaReferenceMetric>();
 
             foreach (var projectResult in PortSolutionResult.ProjectResults)
             {
@@ -97,12 +102,14 @@ namespace CTA.Rules.Metrics
                 upgradePackageMetrics.AddRange(MetricsTransformer.TransformUpgradePackages(Context, projectResult));
                 actionPackageMetrics.AddRange(MetricsTransformer.TransformActionPackages(Context, projectResult));
                 actionExecutionMetrics.AddRange(MetricsTransformer.TransformGenericActionExecutions(Context, projectResult));
+                missingMetaReferenceMetrics.AddRange(MetricsTransformer.TransformMissingMetaReferences(Context, projectResult));
             }
 
             TargetVersionMetrics = targetVersionMetrics;
             UpgradePackageMetrics = upgradePackageMetrics;
             ActionPackageMetrics = actionPackageMetrics;
             GenericActionExecutionMetrics = actionExecutionMetrics;
+            MissingMetaReferenceMetrics = missingMetaReferenceMetrics;
         }
 
         private string GenerateAnalyzeSolutionResultJsonReport()
@@ -113,6 +120,7 @@ namespace CTA.Rules.Metrics
                 .Concat(ActionPackageMetrics)
                 .Concat(GenericActionMetrics)
                 .Concat(FeatureDetectionMetrics)
+                .Concat(MissingMetaReferenceMetrics)
                 .ToList();
 
             AnalyzeSolutionResultJsonReport = JsonConvert.SerializeObject(allMetrics);
@@ -129,6 +137,7 @@ namespace CTA.Rules.Metrics
                 .Concat(ActionPackageMetrics)
                 .Concat(GenericActionExecutionMetrics)
                 .Concat(BuildErrorMetrics)
+                .Concat(MissingMetaReferenceMetrics)
                 .ToList();
 
             PortSolutionResultJsonReport = JsonConvert.SerializeObject(allMetrics);

--- a/src/CTA.Rules.Models/CTA.Rules.Models.csproj
+++ b/src/CTA.Rules.Models/CTA.Rules.Models.csproj
@@ -11,8 +11,8 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Codelyzer.Analysis" Version="1.6.8-alpha-g34252ac19a" />
-    <PackageReference Include="Codelyzer.Analysis.Model" Version="1.6.8-alpha-g34252ac19a" />
+    <PackageReference Include="Codelyzer.Analysis" Version="1.6.18-alpha-gb5c231484b" />
+    <PackageReference Include="Codelyzer.Analysis.Model" Version="1.6.18-alpha-gb5c231484b" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/CTA.Rules.Models/ProjectResult.cs
+++ b/src/CTA.Rules.Models/ProjectResult.cs
@@ -10,6 +10,7 @@ namespace CTA.Rules.Models
         public List<PackageAction> ActionPackages { get; set; }
         public List<string> TargetVersions { get; set; }
         public List<string> MetaReferences { get; set; }
+        public List<string> MissingMetaReferences { get; set; }
 
         public ProjectResult()
         {

--- a/src/CTA.Rules.Update/ProjectRewriter.cs
+++ b/src/CTA.Rules.Update/ProjectRewriter.cs
@@ -41,8 +41,9 @@ namespace CTA.Rules.Update
                     Name = p.Key,
                     OriginalVersion = p.Value.Item1,
                     Version = p.Value.Item2
-                }).ToList()
-            };
+                }).ToList(),
+                MissingMetaReferences = analyzerResult?.ProjectBuildResult?.MissingReferences
+        };
 
             _sourceFileBuildResults = analyzerResult?.ProjectBuildResult?.SourceFileBuildResults;
             _sourceFileResults = analyzerResult?.ProjectResult?.SourceFileResults;

--- a/tst/CTA.Rules.Test/Metrics/PortSolutionResultReportGeneratorTests.cs
+++ b/tst/CTA.Rules.Test/Metrics/PortSolutionResultReportGeneratorTests.cs
@@ -80,6 +80,7 @@ namespace CTA.Rules.Test.Metrics
                     ProjectFile = projectPath1,
                     TargetVersions = new List<string>() {Constants.DefaultCoreVersion},
                     UpgradePackages = new List<PackageAction>() {new PackageAction() { Name = "Newtonsoft.Json", OriginalVersion="9.0.0", Version="12.0.0" } },
+                    MissingMetaReferences = new List<string> { @"C://reference1.dll", @"C://reference2.dll" },
                     ProjectActions = new ProjectActions() {
                         FileActions = new BlockingCollection<FileActions>()
                         {
@@ -211,6 +212,20 @@ namespace CTA.Rules.Test.Metrics
     ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
     ""projectGuid"": ""1234-5678"",
     ""filePath"": ""eb98c1d648bc61064bdeaca9523a49e51bb3312f28f59376fb385e1569c77822""
+  },
+  {
+    ""metricsType"": ""CTA"",
+    ""metricName"": ""MissingMetaReference"",
+    ""metaReference"": ""C://reference1.dll"",
+    ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
+    ""projectGuid"": ""1234-5678""
+  },
+  {
+    ""metricsType"": ""CTA"",
+    ""metricName"": ""MissingMetaReference"",
+    ""metaReference"": ""C://reference2.dll"",
+    ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
+    ""projectGuid"": ""1234-5678""
   }
 ]";
             var formattedReport = JValue.Parse(ReportGenerator.AnalyzeSolutionResultJsonReport.Trim()).ToString(Formatting.Indented);
@@ -261,6 +276,20 @@ namespace CTA.Rules.Test.Metrics
     ""metricsType"": ""CTA"",
     ""metricName"": ""DetectedFeature"",
     ""featureName"": ""Feature 1a"",
+    ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
+    ""projectGuid"": ""1234-5678""
+  },
+  {
+    ""metricsType"": ""CTA"",
+    ""metricName"": ""MissingMetaReference"",
+    ""metaReference"": ""C://reference1.dll"",
+    ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
+    ""projectGuid"": ""1234-5678""
+  },
+  {
+    ""metricsType"": ""CTA"",
+    ""metricName"": ""MissingMetaReference"",
+    ""metaReference"": ""C://reference2.dll"",
     ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
     ""projectGuid"": ""1234-5678""
   }
@@ -442,6 +471,20 @@ Count: 400";
     ""count"": 400,
     ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
     ""projectGuid"": ""N/A""
+  },
+  {
+    ""metricsType"": ""CTA"",
+    ""metricName"": ""MissingMetaReference"",
+    ""metaReference"": ""C://reference1.dll"",
+    ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
+    ""projectGuid"": ""1234-5678""
+  },
+  {
+    ""metricsType"": ""CTA"",
+    ""metricName"": ""MissingMetaReference"",
+    ""metaReference"": ""C://reference2.dll"",
+    ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
+    ""projectGuid"": ""1234-5678""
   }
 ]";
             var unformattedReport = ReportGenerator.PortSolutionResultJsonReport.Trim();


### PR DESCRIPTION
## Related issue

Closes: #198


## Description
[This PR](https://github.com/aws/codelyzer/pull/86/files) saves non-exist meta references (E.g. `C:\\Users\\administrator\\source\\repos\\TestProject\\src\\packages\\EntityFramework.6.1.1\\lib\\net45\\EntityFramework.dll`) to `ProjectBuildResult.MissingReferences`. In this patch, we add `MissingReferences` to CTA metrics for ops tracking.

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
