### PR TITLE
Fix unit test and remove old framework directive

### DIFF
--- a/tst/CTA.Rules.Test/Models/ExpectedOutputConstants.cs
+++ b/tst/CTA.Rules.Test/Models/ExpectedOutputConstants.cs
@@ -10,15 +10,17 @@ namespace CTA.Rules.Test.Models
 @"/* Added by CTA: OAuth is now handled by using the public void ConfigureServices(IServiceCollection services) method in the Startup.cs class. The basic process is to use services.AddAuthentication(options => and then set a series of options. We can chain unto that the actual OAuth settings call services.AddOAuth(""Auth_Service_here_such_as_GitHub_Canvas..."", options =>. Also remember to add a call to IApplicationBuilder.UseAuthentication() in your public void Configure(IApplicationBuilder app, IHostingEnvironment env) method. Please ensure this call comes before setting up your routes. */
 using System.Threading.Tasks;
 using System;
-using Microsoft.Owin.Security.Google;
+using Microsoft.Owin.Security.Notifications;
 using System.Security.Claims;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Owin.Security.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols;
 using Microsoft.AspNetCore.Owin;
-using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authentication;
@@ -102,6 +104,14 @@ namespace AspNetRoutes
             logger.LogInformation(""message"");
             /* Added by CTA: Please add IApplicationBuilder.UseAuthentication() in your configure method. Within your public void ConfigureServices(IServiceCollection services) method please add services.AddAuthentication().AddGoogle(options => { IConfigurationSection googleAuthNSection = Configuration.GetSection(""Authentication:Google""); options.ClientId = googleAuthNSection[""ClientId""]; options.ClientSecret = googleAuthNSection[""ClientSecret""]; } ); */
             app.UseGoogleAuthentication(new GoogleOAuth2AuthenticationOptions());
+        }
+
+        public void OnAuthenticationFailed(HttpContext context, BaseNotification<OpenIdConnectAuthenticationOptions> baseNotif)
+        {
+            OpenIdConnectAuthenticationOptions options = new OpenIdConnectAuthenticationOptions();
+            RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> redirectContext = new RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>(context, options);
+            redirectContext.HandleResponse();
+            baseNotif.HandleResponse();
         }
     }
 }";

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -869,6 +869,16 @@
               "Type": "Package",
               "Value": "Microsoft.AspNetCore.Authentication.Google",
               "Description": "Add package Microsoft.AspNetCore.Authentication.Google"
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.Google",
+              "Description": "Remove Microsoft.Owin.Security.Google",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.Google;"
+              }
             }
           ]
         },
@@ -902,6 +912,16 @@
                 "Version": "3.1.18"
               },
               "Description": "Add package Microsoft.AspNetCore.Authentication.Google version 3.1.18"
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.Google",
+              "Description": "Remove Microsoft.Owin.Security.Google",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.Google;"
+              }
             }
           ]
         }


### PR DESCRIPTION
## Related issue

Closes: #ISSUE_NUMBER_HERE


## Description
Rectify unit tests to account for new APIs in test project and also remove old framework owin directive.

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
