### PR TITLE
Add .NET 6 test cases for .NET 6 rules

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,6 +25,11 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+        include-prerelease: true
     - name: Install dependencies
       run: dotnet restore src/CTA.Rules.sln
     - name: Build

--- a/src/CTA.Rules.Actions/ProjectLevelActions.cs
+++ b/src/CTA.Rules.Actions/ProjectLevelActions.cs
@@ -56,18 +56,7 @@ namespace CTA.Rules.Actions
             return func;
         }
 
-        public Func<string, ProjectType, string> GetCreateNet3FolderHierarchyAction(string _)
-        {
-            static string func(string projectDir, ProjectType projectType)
-            {
-                FolderUpdate folderUpdate = new FolderUpdate(projectDir, projectType);
-                return folderUpdate.Run();
-            }
-
-            return func;
-        }
-
-        public Func<string, ProjectType, string> GetCreateNet5FolderHierarchyAction(string _)
+        public Func<string, ProjectType, string> GetCreateNetCoreFolderHierarchyAction(string _)
         {
             static string func(string projectDir, ProjectType projectType)
             {

--- a/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
+++ b/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
@@ -23,8 +23,9 @@ namespace CTA.Rules.Test
 
         protected static class TargetFramework
         {
-            public const string Dotnet5 = "net5.0";
             public const string DotnetCoreApp31 = "netcoreapp3.1";
+            public const string Dotnet5 = "net5.0";
+            public const string Dotnet6 = "net6.0";
         }
 
         protected void Setup(System.Type type)

--- a/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
+++ b/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
@@ -33,6 +33,165 @@
     <None Update="CTAFiles\action.namespace.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TempRules\antlr.runtime.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\antlr.runtime.misc.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\antlr.runtime.tree.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.channels.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.codebased.project.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.configurationbased.project.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.description.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.diagnostics.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.dispatcher.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.identitymodel.claims.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.identitymodel.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.identitymodel.policy.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.identitymodel.selectors.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.identitymodel.services.tokens.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.identitymodel.tokens.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.security.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.security.tokens.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\corewcf.servicelibrary.project.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\ionic.bzip2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\ionic.crc.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\ionic.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\ionic.zip.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\ionic.zlib.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.aspnet.identity.owin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.filesystems.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.hosting.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.infrastructure.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.logging.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.security.authorization.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.security.datahandler.encoder.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.security.datahandler.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.security.dataprotection.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.security.infrastructure.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.security.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.security.notifications.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.security.openidconnect.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\microsoft.owin.staticfiles.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\owin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\project.all.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.collections.specialized.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.data.entity.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.data.sqlclient.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.runtime.caching.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.web.configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.web.http.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.web.http.odata.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.web.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\system.web.mvc.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TempRules\wcf.client.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestFiles\Configs\Web.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -20,6 +20,7 @@ namespace CTA.Rules.Test
             downloadLocation = SetupTests.DownloadLocation;
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestAspNetRoutes(string version)
@@ -42,7 +43,10 @@ namespace CTA.Rules.Test
 
             StringAssert.Contains(@"Microsoft.AspNetCore.Owin", csProjContent);
             StringAssert.Contains(@"Microsoft.AspNetCore.Diagnostics", csProjContent);
-            StringAssert.Contains(version == TargetFramework.Dotnet5 ? @"Microsoft.AspNetCore.Authentication.Google" : @"<PackageReference Include=""Microsoft.AspNetCore.Authentication.Google"" Version=""3.1.18"" />", csProjContent);
+            StringAssert.Contains(new[] { TargetFramework.Dotnet5, TargetFramework.Dotnet6 }.Contains(version) 
+                ? @"Microsoft.AspNetCore.Authentication.Google" 
+                : @"<PackageReference Include=""Microsoft.AspNetCore.Authentication.Google"" Version=""3.1.18"" />", 
+                csProjContent);
 
             //Check that correct version is used
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
@@ -50,6 +54,7 @@ namespace CTA.Rules.Test
 
 
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBranchingPipelines(string version)
@@ -77,6 +82,7 @@ namespace CTA.Rules.Test
             //FileAssert.Exists(Path.Combine(projectDir, "Program.cs")); // This should be added but class library does not do this
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestEmbedded(string version)
@@ -102,6 +108,7 @@ namespace CTA.Rules.Test
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestCustomServer(string version)
@@ -145,7 +152,7 @@ namespace CTA.Rules.Test
             Assert.True(customProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
-
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestHelloWorld(string version)
@@ -168,6 +175,7 @@ namespace CTA.Rules.Test
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestHelloWorldRawOwin(string version)
@@ -187,6 +195,7 @@ namespace CTA.Rules.Test
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestOwinSelfHostSample(string version)
@@ -210,6 +219,7 @@ namespace CTA.Rules.Test
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestSignalR(string version)
@@ -234,6 +244,7 @@ namespace CTA.Rules.Test
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestStaticFilesSample(string version)
@@ -260,6 +271,7 @@ namespace CTA.Rules.Test
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestWebApi(string version)
@@ -273,14 +285,17 @@ namespace CTA.Rules.Test
             StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinWebApiStartup, startupText);
 
             //Check that package has been added:
-            StringAssert.Contains(version == TargetFramework.Dotnet5 ? @"Microsoft.AspNetCore.Authentication.OpenIdConnect" : @"<PackageReference Include=""Microsoft.AspNetCore.Authentication.OpenIdConnect"" Version=""3.1.15"" />", csProjContent);
+            StringAssert.Contains(new []{TargetFramework.Dotnet5, TargetFramework.Dotnet6}.Contains(version) 
+                ? @"Microsoft.AspNetCore.Authentication.OpenIdConnect" 
+                : @"<PackageReference Include=""Microsoft.AspNetCore.Authentication.OpenIdConnect"" Version=""3.1.15"" />", 
+                csProjContent);
             StringAssert.Contains(@"Microsoft.AspNetCore.Diagnostics", csProjContent);
 
             //Check that correct version is used
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
-
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestWebSocketSample(string version)
@@ -316,6 +331,7 @@ namespace CTA.Rules.Test
             Assert.True(serverProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestOwinExtraAPI(string version)
@@ -333,6 +349,7 @@ namespace CTA.Rules.Test
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestOwinParadise(string version)

--- a/tst/CTA.Rules.Test/PortCoreTests.cs
+++ b/tst/CTA.Rules.Test/PortCoreTests.cs
@@ -52,6 +52,7 @@ namespace CTA.Rules.Test
             TestWebApi(TargetFramework.Dotnet5, solutionDir);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         public void TestWebApi(string version, string solutionDir = "")
         {
@@ -257,8 +258,9 @@ namespace CTA.Rules.Test
             Assert.AreEqual(webApiProjectActions.Count, 4);
         }
 
-        [TestCase(TargetFramework.DotnetCoreApp31)]
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
+        [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestMvcMusicStore(string version)
         {
             var solutionPath = CopySolutionFolderToTemp("MvcMusicStore.sln", tempDir);
@@ -267,6 +269,7 @@ namespace CTA.Rules.Test
             ValidateMvcMusicStore(results, version);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestMvcMusicStoreWithReferences(string version)
@@ -280,6 +283,7 @@ namespace CTA.Rules.Test
             ValidateMvcMusicStore(results, version);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestMvcMusicStoreWithoutProjectPort(string version)
@@ -401,6 +405,8 @@ namespace CTA.Rules.Test
             Assert.AreEqual(mvcProjectActions.Count, 4);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
+        [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestAntlrSampleSolution(string version)
         {
@@ -419,6 +425,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains("Include=\"Antlr3.Runtime\"", csProjectContent);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestMvcConfigSampleSolution(string version)
@@ -431,6 +438,7 @@ namespace CTA.Rules.Test
             ValidateConfig(homeControllerText);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestWebApiConfigSampleSolution(string version)
@@ -444,8 +452,9 @@ namespace CTA.Rules.Test
 
         }
 
-        [TestCase(TargetFramework.DotnetCoreApp31)]
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
+        [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBuildableMvcSolution(string version)
         {
             TestSolutionAnalysis resultWithoutCodePort = AnalyzeSolution("BuildableMvc.sln", tempDir, downloadLocation, version, portCode: false);
@@ -457,8 +466,9 @@ namespace CTA.Rules.Test
             Assert.AreEqual(0, buildErrors.Count);
         }
 
-        [TestCase(TargetFramework.DotnetCoreApp31)]
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
+        [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBuildableWebApiSolution(string version)
         {
             TestSolutionAnalysis resultWithoutCodePort = AnalyzeSolution("BuildableWebApi.sln", tempDir, downloadLocation, version, portCode: false);
@@ -470,9 +480,9 @@ namespace CTA.Rules.Test
             Assert.AreEqual(buildErrors.Count, 0);
         }
 
-
-        [TestCase(TargetFramework.DotnetCoreApp31)]
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
+        [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestSampleMvcWebApiSolution(string version)
         {
             TestSolutionAnalysis results = AnalyzeSolution("SampleMvcWebApp.sln", tempDir, downloadLocation, version);
@@ -486,7 +496,9 @@ namespace CTA.Rules.Test
             StringAssert.Contains("TryUpdateModelAsync", homeController);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
+        [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestMemoryUsageForMvcWebApiSolution(string version)
         {
             // This upper limit was chosen by taking the avg memory consumption of this
@@ -532,6 +544,8 @@ namespace CTA.Rules.Test
             StringAssert.DoesNotContain(@"var appSetting3 = WebConfigurationManager.AppSettings[constAppSetting];", controllerText);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
+        [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestIonicZipSampleSolution(string version)
         {

--- a/tst/CTA.Rules.Test/PortCoreTests.cs
+++ b/tst/CTA.Rules.Test/PortCoreTests.cs
@@ -116,13 +116,13 @@ namespace CTA.Rules.Test
             //When running it the first time
             if (string.IsNullOrEmpty(solutionDir))
             {
-                Assert.AreEqual(webApiProjectActions.Count, 4);
+                Assert.AreEqual(4, webApiProjectActions.Count);
             }
 
             //When running the second time
             else
             {
-                Assert.AreEqual(webApiProjectActions.Count, 2);
+                Assert.AreEqual(2, webApiProjectActions.Count);
             }
             return Directory.GetParent(results.SolutionRunResult.SolutionPath).FullName;
         }
@@ -253,9 +253,9 @@ namespace CTA.Rules.Test
             var webApiProjectActions = results.SolutionRunResult.ProjectResults.First(p => p.ProjectFile.EndsWith("WebApiWithReferences.csproj"))
                 .ExecutedActions.First(a => a.Key == "Project").Value;
 
-            Assert.AreEqual(classlibrary1Actions.Count, 2);
-            Assert.AreEqual(classlibrary2Actions.Count, 2);
-            Assert.AreEqual(webApiProjectActions.Count, 4);
+            Assert.AreEqual(2, classlibrary1Actions.Count);
+            Assert.AreEqual(2, classlibrary2Actions.Count);
+            Assert.AreEqual(4, webApiProjectActions.Count);
         }
 
         [TestCase(TargetFramework.Dotnet6)]
@@ -402,7 +402,7 @@ namespace CTA.Rules.Test
             var mvcProjectActions = results.SolutionRunResult.ProjectResults.First(p => p.ProjectFile.EndsWith("MvcMusicStore.csproj"))
                 .ExecutedActions.First(a => a.Key == "Project").Value;
 
-            Assert.AreEqual(mvcProjectActions.Count, 4);
+            Assert.AreEqual(4, mvcProjectActions.Count);
         }
 
         [TestCase(TargetFramework.Dotnet6)]
@@ -477,7 +477,7 @@ namespace CTA.Rules.Test
 
             TestSolutionAnalysis results = AnalyzeSolution("BuildableWebApi.sln", tempDir, downloadLocation, version);
             var buildErrors = GetSolutionBuildErrors(results.SolutionRunResult.SolutionPath);
-            Assert.AreEqual(buildErrors.Count, 0);
+            Assert.AreEqual(0, buildErrors.Count);
         }
 
         [TestCase(TargetFramework.Dotnet6)]

--- a/tst/CTA.Rules.Test/TempRules/antlr.runtime.json
+++ b/tst/CTA.Rules.Test/TempRules/antlr.runtime.json
@@ -1,0 +1,62 @@
+{
+  "Name": "Antlr.Runtime",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Antlr.Runtime",
+      "Value": "Antlr.Runtime",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Antlr3.Runtime",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Antlr3.Runtime",
+              "Description": "Add package Antlr3.Runtime"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/antlr.runtime.misc.json
+++ b/tst/CTA.Rules.Test/TempRules/antlr.runtime.misc.json
@@ -1,0 +1,62 @@
+{
+  "Name": "Antlr.Runtime.Misc",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Antlr.Runtime.Misc",
+      "Value": "Antlr.Runtime.Misc",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add reference to Antlr3.Runtime",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Antlr3.Runtime",
+              "Description": "Add package Antlr3.Runtime"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/antlr.runtime.tree.json
+++ b/tst/CTA.Rules.Test/TempRules/antlr.runtime.tree.json
@@ -1,0 +1,62 @@
+{
+  "Name": "Antlr.Runtime.Tree",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Antlr.Runtime.Tree",
+      "Value": "Antlr.Runtime.Tree",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Antlr3.Runtime",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Antlr3.Runtime",
+              "Description": "Add package Antlr3.Runtime"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.channels.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.channels.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.Channels",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.Channels",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.ServiceModel.Channels",
+      "Value": "System.ServiceModel.Channels",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.ServiceModel.Channels with CoreWCF.Channels Namespace. Check CoreWCF Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.Channels",
+              "Description": "Add CoreWCF.Channels Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.ServiceModel.Channels",
+              "Description": "Remove System.ServiceModel.Channels Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.codebased.project.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.codebased.project.json
@@ -1,0 +1,79 @@
+{
+  "Name": "CoreWCF.CodeBased.Project",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Project",
+      "Type": "Project"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Project",
+      "Name": "Project",
+      "Value": "WCFCodeBasedService",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.Primitives",
+              "Description": "Add package CoreWCF.Primitives."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.Http",
+              "Description": "Add package CoreWCF.Http."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.NetTcp",
+              "Description": "Add package CoreWCF.NetTcp."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore",
+              "Description": "Add package Microsoft.AspNetCore."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.configuration.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.configuration.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.Configuration",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.Configuration",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.ServiceModel.Configuration",
+      "Value": "System.ServiceModel.Configuration",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.ServiceModel.Configuration with CoreWCF.Configuration Namespace. Check CoreWCF.Configuration Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.Configuration",
+              "Description": "Add CoreWCF.Configuration Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.ServiceModel.Configuration",
+              "Description": "Remove System.ServiceModel.Configuration Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.configurationbased.project.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.configurationbased.project.json
@@ -1,0 +1,85 @@
+{
+  "Name": "CoreWCF.ConfigurationBased.Project",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Project",
+      "Type": "Project"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Project",
+      "Name": "Project",
+      "Value": "WCFConfigBasedService",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.Primitives",
+              "Description": "Add package CoreWCF.Primitives."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.Http",
+              "Description": "Add package CoreWCF.Http."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.NetTcp",
+              "Description": "Add package CoreWCF.NetTcp."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore",
+              "Description": "Add package Microsoft.AspNetCore."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.ConfigurationManager",
+              "Description": "Add package CoreWCF.ConfigurationManager."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.description.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.description.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.Description",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.Description",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.ServiceModel.Description",
+      "Value": "System.ServiceModel.Description",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.ServiceModel.Description with CoreWCF.Description Namespace. Check CoreWCF.Description Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.Description",
+              "Description": "Add CoreWCF.Description Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.ServiceModel.Description",
+              "Description": "Remove System.ServiceModel.Description Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.diagnostics.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.diagnostics.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.Diagnostics",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.Diagnostics",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.ServiceModel.Diagnostics",
+      "Value": "System.ServiceModel.Diagnostics",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.ServiceModel.Diagnostics with CoreWCF.Diagnostics Namespace. Check CoreWCF.Diagnostics Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.Diagnostics",
+              "Description": "Add CoreWCF.Diagnostics Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.ServiceModel.Diagnostics",
+              "Description": "Remove System.ServiceModel.Diagnostics Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.dispatcher.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.dispatcher.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.Dispatcher",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.Dispatcher",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.ServiceModel.Dispatcher",
+      "Value": "System.ServiceModel.Dispatcher",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.ServiceModel.Dispatcher with CoreWCF.Dispatcher Namespace. Check CoreWCF.Dispatcher Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.Dispatcher",
+              "Description": "Add CoreWCF.Dispatcher Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.ServiceModel.Dispatcher",
+              "Description": "Remove System.ServiceModel.Dispatcher Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.claims.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.claims.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.IdentityModel.Claims",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.IdentityModel.Claims",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.IdentityModel.Claims",
+      "Value": "System.IdentityModel.Claims",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.IdentityModel.Claims with CoreWCF.IdentityModel.Claims Namespace. Check CoreWCF.IdentityModel.Claims Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.IdentityModel.Claims",
+              "Description": "Add CoreWCF.IdentityModel.Claims Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.IdentityModel.Claims",
+              "Description": "Remove System.IdentityModel.Claims Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.IdentityModel",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.IdentityModel",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.IdentityModel",
+      "Value": "System.IdentityModel",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.IdentityModel with CoreWCF.IdentityModel Namespace. Check CoreWCF.IdentityModel Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.IdentityModel",
+              "Description": "Add CoreWCF.IdentityModel Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.IdentityModel",
+              "Description": "Remove System.IdentityModel Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.policy.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.policy.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.IdentityModel.Policy",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.IdentityModel.Policy",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.IdentityModel.Policy",
+      "Value": "System.IdentityModel.Policy",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.IdentityModel.Policy with CoreWCF.IdentityModel.Policy Namespace. Check CoreWCF.IdentityModel.Policy Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.IdentityModel.Policy",
+              "Description": "Add CoreWCF.IdentityModel.Policy Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.IdentityModel.Policy",
+              "Description": "Remove System.IdentityModel.Policy Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.selectors.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.selectors.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.IdentityModel.Selectors",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.IdentityModel.Selectors",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.IdentityModel.Selectors",
+      "Value": "System.IdentityModel.Selectors",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.IdentityModel.Selectors with CoreWCF.IdentityModel.Selectors Namespace. Check CoreWCF.IdentityModel.Selectors Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.IdentityModel.Selectors",
+              "Description": "Add CoreWCF.IdentityModel.Selectors Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.IdentityModel.Selectors",
+              "Description": "Remove System.IdentityModel.Selectors Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.services.tokens.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.services.tokens.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.IdentityModel.Services.Tokens",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.IdentityModel.Services.Tokens",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.IdentityModel.Services.Tokens",
+      "Value": "System.IdentityModel.Services.Tokens",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.IdentityModel.Services.Tokens with CoreWCF.IdentityModel.Services.Tokens Namespace. Check CoreWCF.IdentityModel.Services.Tokens Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.IdentityModel.Services.Tokens",
+              "Description": "Add CoreWCF.IdentityModel.Services.Tokens Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.IdentityModel.Services.Tokens",
+              "Description": "Remove System.IdentityModel.Services.Tokens Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.tokens.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.identitymodel.tokens.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.IdentityModel.Tokens",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.IdentityModel.Tokens",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.IdentityModel.Tokens",
+      "Value": "System.IdentityModel.Tokens",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.IdentityModel.Tokens with CoreWCF.IdentityModel.Tokens Namespace. Check CoreWCF.IdentityModel.Tokens Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.IdentityModel.Tokens",
+              "Description": "Add CoreWCF.IdentityModel.Tokens Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.IdentityModel.Tokens",
+              "Description": "Remove System.IdentityModel.Tokens Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.ServiceModel",
+      "Value": "System.ServiceModel",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.ServiceModel with CoreWCF Namespace. Check CoreWCF Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF",
+              "Description": "Add CoreWCF Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.ServiceModel",
+              "Description": "Remove System.ServiceModel Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.security.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.security.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.Security",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.Security",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.ServiceModel.Security",
+      "Value": "System.ServiceModel.Security",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.ServiceModel.Security with CoreWCF.Security Namespace. Check CoreWCF.Security Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.Security",
+              "Description": "Add CoreWCF.Security Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.ServiceModel.Security",
+              "Description": "Remove System.ServiceModel.Security Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.security.tokens.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.security.tokens.json
@@ -1,0 +1,68 @@
+{
+  "Name": "CoreWCF.Security.Tokens",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "CoreWCF.Security.Tokens",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.ServiceModel.Security.Tokens",
+      "Value": "System.ServiceModel.Security.Tokens",
+      "KeyType": "Name",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.ServiceModel.Security.Tokens with CoreWCF.Security.Tokens Namespace. Check CoreWCF.Security.Tokens Compatibility at https://github.com/CoreWCF/CoreWCF/releases",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "CoreWCF.Security.Tokens",
+              "Description": "Add CoreWCF.Security.Tokens Namespace."
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.ServiceModel.Security.Tokens",
+              "Description": "Remove System.ServiceModel.Security.Tokens Namespace."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/corewcf.servicelibrary.project.json
+++ b/tst/CTA.Rules.Test/TempRules/corewcf.servicelibrary.project.json
@@ -1,0 +1,79 @@
+{
+  "Name": "CoreWCF.ServiceLibrary.Project",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Project",
+      "Type": "Project"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Project",
+      "Name": "Project",
+      "Value": "WCFServiceLibrary",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.Primitives",
+              "Description": "Add package CoreWCF.Primitives."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.Http",
+              "Description": "Add package CoreWCF.Http."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "CoreWCF.NetTcp",
+              "Description": "Add package CoreWCF.NetTcp."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore",
+              "Description": "Add package Microsoft.AspNetCore."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/ionic.bzip2.json
+++ b/tst/CTA.Rules.Test/TempRules/ionic.bzip2.json
@@ -1,0 +1,62 @@
+{
+  "Name": "Ionic.BZip2",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic.BZip2",
+      "Value": "Ionic.BZip2",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/ionic.crc.json
+++ b/tst/CTA.Rules.Test/TempRules/ionic.crc.json
@@ -1,0 +1,62 @@
+{
+  "Name": "Ionic.Crc",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic.Crc",
+      "Value": "Ionic.Crc",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/ionic.json
+++ b/tst/CTA.Rules.Test/TempRules/ionic.json
@@ -1,0 +1,62 @@
+{
+  "Name": "Ionic",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic",
+      "Value": "Ionic",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/ionic.zip.json
+++ b/tst/CTA.Rules.Test/TempRules/ionic.zip.json
@@ -1,0 +1,62 @@
+{
+  "Name": "Ionic.Zip",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic.Zip",
+      "Value": "Ionic.Zip",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/ionic.zlib.json
+++ b/tst/CTA.Rules.Test/TempRules/ionic.zlib.json
@@ -1,0 +1,62 @@
+{
+  "Name": "Ionic.Zlib",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic.Zlib",
+      "Value": "Ionic.Zlib",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.aspnet.identity.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.aspnet.identity.owin.json
@@ -1,0 +1,77 @@
+{
+  "Name": "Microsoft.AspNet.Identity.Owin",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.AspNet.Identity.Owin",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.AspNet.Identity.Owin",
+      "Value": "Microsoft.AspNet.Identity.Owin",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Identity and remove Microsoft.AspNet.Identity.Owin.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Identity",
+              "Description": "Add Microsoft.AspNetCore.Identity namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Identity;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNet.Identity.Owin",
+              "Description": "Remove Microsoft.AspNet.Identity.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.AspNet.Identity.Owin;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.filesystems.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.filesystems.json
@@ -1,0 +1,67 @@
+{
+  "Name": "Microsoft.Owin.FileSystems",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.FileSystems",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Class",
+      "Name": "PhysicalFileSystem",
+      "Value": "Microsoft.Owin.FileSystems.PhysicalFileSystem",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace PhysicalFileSystem with PhysicalFileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "PhysicalFileProvider",
+              "Description": "Replace PhysicalFileSystem with PhysicalFileProvider",
+              "ActionValidation": {
+                "Contains": "PhysicalFileProvider",
+                "NotContains": "PhysicalFileSystem"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.hosting.json
@@ -1,0 +1,221 @@
+{
+  "Name": "Microsoft.Owin.Hosting",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Hosting",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Hosting",
+      "Value": "Microsoft.Owin.Hosting",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Hosting, Microsoft.AspNetCore.Server.Kestrel and remove Microsoft.Owin.Hosting and Owin.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Hosting",
+              "Description": "Add package Microsoft.AspNetCore.Hosting"
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Server.Kestrel",
+              "Description": "Add package Microsoft.AspNetCore.Server.Kestrel"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Hosting",
+              "Description": "Add Microsoft.AspNetCore.Hosting namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Hosting;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Server.Kestrel",
+              "Description": "Add Microsoft.AspNetCore.Server.Kestrel namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Server.Kestrel;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Hosting",
+              "Description": "Remove Microsoft.Owin.Hosting namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Hosting;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Owin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(Microsoft.Owin.Hosting.StartOptions)",
+      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(Microsoft.Owin.Hosting.StartOptions)",
+      "KeyType": "Name",
+      "ContainingType": "WebApp",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace WebApp.Start.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Microsoft.Owin.Hosting.WebApp.Start with WebHostBuilder such as: var host = new WebHostBuilder().UseKestrel().UseUrls(URL_HERE).UseStartup<Startup>().Build(); host.Start(); Start options can be added into the new format as needed.",
+              "Description": "Add a comment to explain how to replace WebApp.Start.",
+              "ActionValidation": {
+                "Contains": "Replace Microsoft.Owin.Hosting.WebApp.Start with WebHostBuilder such as: var host = new WebHostBuilder().UseKestrel().UseUrls(URL_HERE).UseStartup<Startup>().Build(); host.Start(); Start options can be added into the new format as needed.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(string)",
+      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(string)",
+      "KeyType": "Name",
+      "ContainingType": "WebApp",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace WebApp.Start.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Microsoft.Owin.Hosting.WebApp.Start with WebHostBuilder such as: var host = new WebHostBuilder().UseKestrel().UseUrls(URL_HERE).UseStartup<Startup>().Build(); host.Start(); UseStartup can contain the TStartup class used before.",
+              "Description": "Add a comment to explain how to replace WebApp.Start.",
+              "ActionValidation": {
+                "Contains": "Replace Microsoft.Owin.Hosting.WebApp.Start with WebHostBuilder such as: var host = new WebHostBuilder().UseKestrel().UseUrls(URL_HERE).UseStartup<Startup>().Build(); host.Start(); UseStartup can contain the TStartup class used before.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.infrastructure.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.infrastructure.json
@@ -1,0 +1,262 @@
+{
+  "Name": "Microsoft.Owin.Infrastructure",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Infrastructure",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Infrastructure",
+      "Value": "Microsoft.Owin.Infrastructure",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.WebUtilities and remove Microsoft.Owin.Infrastructure.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.WebUtilities",
+              "Description": "Add Microsoft.AspNetCore.WebUtilities namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.WebUtilities;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Infrastructure",
+              "Description": "Remove Microsoft.Owin.Infrastructure namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Infrastructure;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, string)",
+      "Value": "Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, string)",
+      "KeyType": "",
+      "ContainingType": "WebUtilities",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, string) add a comment to explain how to replace the AddQueryString(string, string) invocation and replace WebUtilities.AddQueryString with QueryHelpers.AddQueryString.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace your parameters as the AddQueryString(string, string) method has been deprecated and you must either use the AddQueryString(string, string, string) method or the AddQueryString(string, System.Collections.Generic.IDictionary<string, string>) method.",
+              "Description": "Add a comment to explain how to replace the AddQueryString(string, string) invocation.",
+              "ActionValidation": {
+                "Contains": "Please replace your parameters as the AddQueryString(string, string) method has been deprecated and you must either use the AddQueryString(string, string, string) method or the AddQueryString(string, System.Collections.Generic.IDictionary<string, string>) method.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "WebUtilities.AddQueryString",
+                "newMethod": "QueryHelpers.AddQueryString"
+              },
+              "Description": "Replace WebUtilities.AddQueryString with QueryHelpers.AddQueryString.",
+              "ActionValidation": {
+                "Contains": "QueryHelpers.AddQueryString",
+                "NotContains": "WebUtilities.AddQueryString"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, System.Collections.Generic.IDictionary<string, string>)",
+      "Value": "Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, System.Collections.Generic.IDictionary<string, string>)",
+      "KeyType": "",
+      "ContainingType": "WebUtilities",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, System.Collections.Generic.IDictionary<string, string>) with Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(string, System.Collections.Generic.IDictionary<string, string>).",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "WebUtilities.AddQueryString",
+                "newMethod": "QueryHelpers.AddQueryString"
+              },
+              "Description": "Replace WebUtilities.AddQueryString with QueryHelpers.AddQueryString.",
+              "ActionValidation": {
+                "Contains": "QueryHelpers.AddQueryString",
+                "NotContains": "WebUtilities.AddQueryString"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, string, string)",
+      "Value": "Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, string, string)",
+      "KeyType": "",
+      "ContainingType": "WebUtilities",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace Microsoft.Owin.Infrastructure.WebUtilities.AddQueryString(string, string, string) with Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(string, string, string).",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "WebUtilities.AddQueryString",
+                "newMethod": "QueryHelpers.AddQueryString"
+              },
+              "Description": "Replace WebUtilities.AddQueryString with QueryHelpers.AddQueryString.",
+              "ActionValidation": {
+                "Contains": "QueryHelpers.AddQueryString",
+                "NotContains": "WebUtilities.AddQueryString"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
@@ -100,7 +100,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": "Microsoft.AspNetCore.Owin",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Owin",
+                "Version": "5.0.12"
+              },
               "Description": "Add package Microsoft.AspNetCore.Owin"
             },
             {

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.json
@@ -1,0 +1,1033 @@
+{
+  "Name": "Microsoft.Owin",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin",
+      "Value": "Microsoft.Owin",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Owin and remove Microsoft.Owin and Owin.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Owin",
+                "Version": "3.1.14"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Owin"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Owin",
+              "Description": "Add Microsoft.AspNetCore.Owin namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Owin;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin",
+              "Description": "Remove Microsoft.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingOwin;"
+              }
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Owin and remove Microsoft.Owin and Owin.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Owin",
+              "Description": "Add package Microsoft.AspNetCore.Owin"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Owin",
+              "Description": "Add Microsoft.AspNetCore.Owin namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Owin;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin",
+              "Description": "Remove Microsoft.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Owin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IOwinContext",
+      "Value": "Microsoft.Owin.IOwinContext",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace IOwinContext with HttpContext and add Microsoft.AspNetCore.Http namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpContext",
+              "Description": "Replace IOwinContext with HttpContext",
+              "ActionValidation": {
+                "Contains": "HttpContext",
+                "NotContains": "IOwinContext"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IOwinResponse",
+      "Value": "Microsoft.Owin.IOwinResponse",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace IOwinResponse with HttpResponse and add Microsoft.AspNetCore.Http namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpResponse",
+              "Description": "Replace IOwinResponse with HttpResponse",
+              "ActionValidation": {
+                "Contains": "HttpResponse",
+                "NotContains": "IOwinResponse"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IOwinRequest",
+      "Value": "Microsoft.Owin.IOwinRequest",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace IOwinRequest with HttpRequest and add Microsoft.AspNetCore.Http namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpRequest",
+              "Description": "Replace IOwinRequest with HttpRequest",
+              "ActionValidation": {
+                "Contains": "HttpRequest",
+                "NotContains": "IOwinRequest"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "OwinMiddleware",
+      "Value": "Microsoft.Owin.OwinMiddleware",
+      "KeyType": "BaseClass",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Remove the base class for OwinMiddleware, remove the override method modifier for the invoke method, add a new global expression for RequestDelegate _next, initialize it in the constructor and remove the constructor intializer base(next).",
+          "Actions": [
+            {
+              "Name": "RemoveBaseClass",
+              "Type": "Class",
+              "Value": "OwinMiddleware",
+              "Description": "Remove the base class OwinMiddleware",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ":OwinMiddleware"
+              }
+            },
+            {
+              "Name": "ReplaceMethodModifiers",
+              "Type": "Class",
+              "Value": {
+                "methodName": "Invoke",
+                "modifiers": "public"
+              },
+              "Description": "Replace all the invoke method modifiers with only public in order to remove the override modifier."
+            },
+            {
+              "Name": "AddExpression",
+              "Type": "Class",
+              "Value": "RequestDelegate _next = null;",
+              "Description": "Add a new global variable to replace the OwinMiddleware global abstract variable of Next.",
+              "ActionValidation": {
+                "Contains": "RequestDelegate_next=null;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AppendConstructorExpression",
+              "Type": "Class",
+              "Value": "_next = next;",
+              "Description": "Add a new expression in the constructor to initialize the new variable of _next to the next element in the pipeline.",
+              "ActionValidation": {
+                "Contains": "_next = next;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveConstructorInitializer",
+              "Type": "Class",
+              "Value": "next",
+              "Description": "Remove the base initializer for the constructor.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ":base(next)"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "OwinMiddleware",
+      "Value": "Microsoft.Owin.OwinMiddleware",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace OwinMiddleware with RequestDelegate and add Microsoft.AspNetCore.Http.RequestDelegate namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "RequestDelegate",
+              "Description": "Replace OwinMiddleware with RequestDelegate",
+              "ActionValidation": {
+                "Contains": "RequestDelegate",
+                "NotContains": "OwinMiddleware"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.OwinMiddleware.Invoke(Microsoft.Owin.IOwinContext)",
+      "Value": "Microsoft.Owin.OwinMiddleware.Invoke(Microsoft.Owin.IOwinContext)",
+      "KeyType": "Name",
+      "ContainingType": "OwinMiddleware",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodWithObject",
+              "Type": "Method",
+              "Value": "_next.Invoke",
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "_next.Invoke",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IReadableStringCollection",
+      "Value": "Microsoft.Owin.IReadableStringCollection",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace IReadableStringCollection with IQueryCollection and add Microsoft.AspNetCore.Http.RequestDelegate namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IQueryCollection",
+              "Description": "Replace IReadableStringCollection with IQueryCollection.",
+              "ActionValidation": {
+                "Contains": "IQueryCollection",
+                "NotContains": "IReadableStringCollection"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.IReadableStringCollection.Get(string)",
+      "Value": "Microsoft.Owin.IReadableStringCollection.Get(string)",
+      "KeyType": "Name",
+      "ContainingType": "IReadableStringCollection",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace the Get method with TryGetValue.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace Get with TryGetValue.",
+              "Description": "Add a comment to explain how to replace IOwinContext.Request.Headers.Get with TryGetValue instead.",
+              "ActionValidation": {
+                "Contains": "Please replace Get with TryGetValue.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.IOwinContext.Get<T>(string)",
+      "Value": "Microsoft.Owin.IOwinContext.Get<T>(string)",
+      "KeyType": "Name",
+      "ContainingType": "IOwinContext",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace the Get method with Items collection.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace Get with Items. Such as (Casting_Type)context.Items[\"String_To_Search_For\"];",
+              "Description": "Add a comment to explain how to replace IOwinContext.Get with HttpContext.Items instead.",
+              "ActionValidation": {
+                "Contains": "Please replace Get with Items. Such as (Casting_Type)context.Items[\"String_To_Search_For\"];",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "RequestCookieCollection",
+      "Value": "Microsoft.Owin.RequestCookieCollection",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace RequestCookieCollection with IRequestCookieCollection and add Microsoft.AspNetCore.Http.RequestDelegate namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IRequestCookieCollection",
+              "Description": "Replace RequestCookieCollection with IRequestCookieCollection.",
+              "ActionValidation": {
+                "Contains": "IRequestCookieCollection",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "ResponseCookieCollection",
+      "Value": "Microsoft.Owin.ResponseCookieCollection",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace ResponseCookieCollection with IResponseCookies and add Microsoft.AspNetCore.Http.RequestDelegate namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IResponseCookies",
+              "Description": "Replace ResponseCookieCollection with IResponseCookies.",
+              "ActionValidation": {
+                "Contains": "IResponseCookies",
+                "NotContains": "ResponseCookieCollection"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IHeaderDictionary",
+      "Value": "Microsoft.Owin.IHeaderDictionary",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Http namespace.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "PathString",
+      "Value": "Microsoft.Owin.PathString",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Http namespace if PathString is being used.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin",
+              "Description": "Remove Microsoft.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.QueryString.QueryString(string, string)",
+      "Value": "Microsoft.Owin.QueryString.QueryString(string, string)",
+      "KeyType": "Name",
+      "ContainingType": "QueryString",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to set the new parameters for QueryString.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "This method only takes a single parameter for the value of the new query string or none at all.",
+              "Description": "Add a comment to explain how to set the new parameters for QueryString.",
+              "ActionValidation": {
+                "Contains": "This method only take a single parameter for the value of the new query string or none at all.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.logging.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.logging.json
@@ -1,0 +1,135 @@
+{
+  "Name": "Microsoft.Owin.Logging",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Logging",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Logging",
+      "Value": "Microsoft.Owin.Logging",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.Extensions.Logging and remove Microsoft.Owin.Logging.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.Logging",
+              "Description": "Add Microsoft.Extensions.Logging namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.Extensions.Logging;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Logging",
+              "Description": "Remove Microsoft.Owin.Logging namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Logging;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Logging.ILogger.WriteInformation(string)",
+      "Value": "Microsoft.Owin.Logging.ILogger.WriteInformation(string)",
+      "KeyType": "",
+      "ContainingType": "LoggerExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Logging.ILogger.WriteInformation(string) replace WriteInformation with LogInformation.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "WriteInformation",
+                "newMethod": "LogInformation"
+              },
+              "Description": "Replace WriteInformation with LogInformation.",
+              "ActionValidation": {
+                "Contains": "LogInformation",
+                "NotContains": "WriteInformation"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.authorization.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.authorization.json
@@ -1,0 +1,77 @@
+{
+  "Name": "Microsoft.Owin.Security.Authorization",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Security.Authorization",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security.Authorization",
+      "Value": "Microsoft.Owin.Security.Authorization",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Remove Microsoft.Owin.Security.Authorization directive and add Microsoft.AspNetCore.Authorization directive.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authorization",
+              "Description": "Add Microsoft.AspNetCore.Authorization namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authorization;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.Authorization",
+              "Description": "Remove Microsoft.Owin.Security.Authorization namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.Authorization;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.datahandler.encoder.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.datahandler.encoder.json
@@ -1,0 +1,179 @@
+{
+  "Name": "Microsoft.Owin.Security.DataHandler.Encoder",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Security.DataHandler.Encoder",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security.DataHandler.Encoder",
+      "Value": "Microsoft.Owin.Security.DataHandler.Encoder",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Remove Microsoft.Owin.Security.DataHandler.Encoder.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.DataHandler.Encoder",
+              "Description": "Remove Microsoft.Owin.Security.DataHandler.Encoder namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.DataHandler.Encoder;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.DataHandler.Encoder.ITextEncoder.Encode(byte[])",
+      "Value": "Microsoft.Owin.Security.DataHandler.Encoder.ITextEncoder.Encode(byte[])",
+      "KeyType": "",
+      "ContainingType": "ITextEncoder",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace the ITextEncoder.Encode method.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace the ITextEncoder with its appropriate class either Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder to encode and decode URLs or System.Text.Encoding for general encoding needs.",
+              "Description": "Add a comment to explain how to replace the ITextEncoder.Encode method.",
+              "ActionValidation": {
+                "Contains": "Please replace the ITextEncoder with its appropriate class either Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder to encode and decode URLs or System.Text.Encoding for general encoding needs.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.DataHandler.Encoder.ITextEncoder.Decode(string)",
+      "Value": "Microsoft.Owin.Security.DataHandler.Encoder.ITextEncoder.Decode(string)",
+      "KeyType": "",
+      "ContainingType": "ITextEncoder",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace the ITextEncoder.Decode method.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace the ITextEncoder with its appropriate class either Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder to encode and decode URLs or System.Text.Encoding for general encoding needs.",
+              "Description": "Add a comment to explain how to replace the ITextEncoder.Decode method.",
+              "ActionValidation": {
+                "Contains": "Please replace the ITextEncoder with its appropriate class either Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder to encode and decode URLs or System.Text.Encoding for general encoding needs.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.datahandler.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.datahandler.json
@@ -1,0 +1,209 @@
+{
+  "Name": "Microsoft.Owin.Security.DataHandler",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Security.DataHandler",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security.DataHandler",
+      "Value": "Microsoft.Owin.Security.DataHandler",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Authentication and remove Microsoft.Owin.Security.DataHandler.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.DataHandler",
+              "Description": "Remove Microsoft.Owin.Security.DataHandler namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.DataHandler;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.DataHandler.Encoder.ITextEncoder.Encode(byte[])",
+      "Value": "Microsoft.Owin.Security.DataHandler.Encoder.ITextEncoder.Encode(byte[])",
+      "KeyType": "",
+      "ContainingType": "ITextEncoder",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace the ITextEncoder.Encode method.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace the ITextEncoder with its appropriate class either Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder to encode and decode URLs or System.Text.Encoding for general encoding needs.",
+              "Description": "Add a comment to explain how to replace the ITextEncoder.Encode method.",
+              "ActionValidation": {
+                "Contains": "Please replace the ITextEncoder with its appropriate class either Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder to encode and decode URLs or System.Text.Encoding for general encoding needs.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.DataHandler.Encoder",
+              "Description": "Remove Microsoft.Owin.Security.DataHandler.Encoder namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.DataHandler.Encoder;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.DataHandler.Encoder.ITextEncoder.Decode(string)",
+      "Value": "Microsoft.Owin.Security.DataHandler.Encoder.ITextEncoder.Decode(string)",
+      "KeyType": "",
+      "ContainingType": "ITextEncoder",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace the ITextEncoder.Decode method.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace the ITextEncoder with its appropriate class either Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder to encode and decode URLs or System.Text.Encoding for general encoding needs.",
+              "Description": "Add a comment to explain how to replace the ITextEncoder.Decode method.",
+              "ActionValidation": {
+                "Contains": "Please replace the ITextEncoder with its appropriate class either Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder to encode and decode URLs or System.Text.Encoding for general encoding needs.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.DataHandler.Encoder",
+              "Description": "Remove Microsoft.Owin.Security.DataHandler.Encoder namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.DataHandler.Encoder;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.dataprotection.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.dataprotection.json
@@ -1,0 +1,249 @@
+{
+  "Name": "Microsoft.Owin.Security.DataProtection",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Security.DataProtection",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security.DataProtection",
+      "Value": "Microsoft.Owin.Security.DataProtection",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.DataProtection and remove Microsoft.Owin.Security.DataProtection.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.DataProtection",
+              "Description": "Add Microsoft.AspNetCore.DataProtection namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.DataProtection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.DataProtection",
+              "Description": "Remove Microsoft.Owin.Security.DataProtection namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.DataProtection;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.DataProtection.IDataProtectionProvider.Create(params string[])",
+      "Value": "Microsoft.Owin.Security.DataProtection.IDataProtectionProvider.Create(params string[])",
+      "KeyType": "",
+      "ContainingType": "IDataProtectionProvider",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.DataProtection.IDataProtectionProvider.Create(params string[]) replace Create method with CreateProtector.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "Create",
+                "newMethod": "CreateProtector"
+              },
+              "Description": "Replace Create api with CreateProtector.",
+              "ActionValidation": {
+                "Contains": "CreateProtector",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.Security.DataProtection.DpapiDataProtectionProvider.DpapiDataProtectionProvider()",
+      "Value": "Microsoft.Owin.Security.DataProtection.DpapiDataProtectionProvider.DpapiDataProtectionProvider()",
+      "KeyType": "Name",
+      "ContainingType": "DpapiDataProtectionProvider",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "When a DpapiDataProtectionProvider class is found add a comment to explain how to replace it with IDataProtectionProvider through dependency injection.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "DpapiDataProtectionProvider should be replaced with a Dependency injection for the IDataProtectionProvider interface. Please include a parameter with this interface to replace this class.",
+              "Description": "Add a comment to explain how to replace DpapiDataProtectionProvider in .net core with IDataProtectionProvider.",
+              "ActionValidation": {
+                "Contains": "DpapiDataProtectionProvider should be replaced with a Dependency injection for the IDataProtectionProvider interface. Please include a parameter with this interface to replace this class.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.DataProtection.DpapiDataProtectionProvider.Create(params string[])",
+      "Value": "Microsoft.Owin.Security.DataProtection.DpapiDataProtectionProvider.Create(params string[])",
+      "KeyType": "",
+      "ContainingType": "DpapiDataProtectionProvider",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.DataProtection.DpapiDataProtectionProvider.Create(params string[]) replace Create method with CreateProtector.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "Create",
+                "newMethod": "CreateProtector"
+              },
+              "Description": "Replace Create api with CreateProtector.",
+              "ActionValidation": {
+                "Contains": "CreateProtector",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.infrastructure.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.infrastructure.json
@@ -1,0 +1,457 @@
+{
+  "Name": "Microsoft.Owin.Security.Infrastructure",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Security.Infrastructure",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security.Infrastructure",
+      "Value": "Microsoft.Owin.Security.Infrastructure",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Microsoft.AspNetCore.Authentication and remove Microsoft.Owin.Security.Infrastructure.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.Infrastructure",
+              "Description": "Remove Microsoft.Owin.Security.Infrastructure namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.Infrastructure;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "AuthenticationTokenCreateContext",
+      "Value": "Microsoft.Owin.Security.Infrastructure.AuthenticationTokenCreateContext",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Authentication namespace and replace AuthenticationTokenCreateContext with TicketSerializer.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "TicketSerializer",
+              "Description": "Replace AuthenticationTokenCreateContext with TicketSerializer",
+              "ActionValidation": {
+                "Contains": "TicketSerializer",
+                "NotContains": "AuthenticationTokenCreateContext"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "AuthenticationTokenReceiveContext",
+      "Value": "Microsoft.Owin.Security.Infrastructure.AuthenticationTokenReceiveContext",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Authentication namespace and replace AuthenticationTokenReceiveContext with TicketSerializer.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "TicketSerializer",
+              "Description": "Replace AuthenticationTokenReceiveContext with TicketSerializer",
+              "ActionValidation": {
+                "Contains": "TicketSerializer",
+                "NotContains": "AuthenticationTokenReceiveContext"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.Infrastructure.AuthenticationTokenCreateContext.SerializeTicket()",
+      "Value": "Microsoft.Owin.Security.Infrastructure.AuthenticationTokenCreateContext.SerializeTicket()",
+      "KeyType": "",
+      "ContainingType": "AuthenticationTokenCreateContext",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.Infrastructure.AuthenticationTokenCreateContext.SerializeTicket() add a comment to explain the new return type and replace SerializeTicket with Serialize.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new parameter as the new method requires Microsoft.AspNetCore.Authentication.AuthenticationTicket to be passed in. The new return type is also a byte[].",
+              "Description": "Add a comment to explain how to replace the SerializeTicket invocation.",
+              "ActionValidation": {
+                "Contains": "Please add a new parameter as the new method requires Microsoft.AspNetCore.Authentication.AuthenticationTicket to be passed in. The new return type is also a byte[].",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "SerializeTicket",
+                "newMethod": "Serialize"
+              },
+              "Description": "Replace SerializeTicket with Serialize.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.Infrastructure.AuthenticationTokenReceiveContext.DeserializeTicket(string)",
+      "Value": "Microsoft.Owin.Security.Infrastructure.AuthenticationTokenReceiveContext.DeserializeTicket(string)",
+      "KeyType": "",
+      "ContainingType": "AuthenticationTokenReceiveContext",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.Infrastructure.AuthenticationTokenReceiveContext.DeserializeTicket(string) add a comment to explain the new return type and replace DeserializeTicket with Deserialize.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please change the parameter type from string to a byte[]. This is also the data type returned by the TicketSerializer.Serialize method. This new method also returns the actual Microsoft.AspNetCore.Authentication.AuthenticationTicket object serialized with the TicketSerializer.Serialize method.",
+              "Description": "Add a comment to explain how to replace the DeserializeTicket invocation.",
+              "ActionValidation": {
+                "Contains": "Please change the parameter type from string to a byte[]. This is also the data type returned by the TicketSerializer.Serialize method.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "DeserializeTicket",
+                "newMethod": "Deserialize"
+              },
+              "Description": "Replace DeserializeTicket with Deserialize.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.Infrastructure.AuthenticationTokenCreateContext.SetToken(string)",
+      "Value": "Microsoft.Owin.Security.Infrastructure.AuthenticationTokenCreateContext.SetToken(string)",
+      "KeyType": "",
+      "ContainingType": "AuthenticationTokenCreateContext",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.Infrastructure.AuthenticationTokenCreateContext.SetToken(string) add a comment to explain the new methods to write information.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please use instead the methods of the TicketSerializer class: WriteIdentity, WriteClaim, Write for AuthenticationTicket or the ReadIdentity, ReadClaim, Read for AuthenticationTicket.",
+              "Description": "Add a comment to explain how to replace the SetToken invocation.",
+              "ActionValidation": {
+                "Contains": "Please use instead the methods of the TicketSerializer class: WriteIdentity, WriteClaim, Write for AuthenticationTicket or the ReadIdentity, ReadClaim, Read for AuthenticationTicket.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.Infrastructure.SecurityHelper.LookupChallenge(string, Microsoft.Owin.Security.AuthenticationMode)",
+      "Value": "Microsoft.Owin.Security.Infrastructure.SecurityHelper.LookupChallenge(string, Microsoft.Owin.Security.AuthenticationMode)",
+      "KeyType": "",
+      "ContainingType": "SecurityHelper",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.Infrastructure.SecurityHelper.LookupChallenge(string, Microsoft.Owin.Security.AuthenticationMode) add a comment to explain how to handle authentication related events.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please use UseAuthentication() in your Configure method in your Startup class and in your ConfigureServices method in your Startup class use AddAuthentication to set all your various options and middleware as needed.",
+              "Description": "Add a comment to explain how to replace the LookupChallenge invocation.",
+              "ActionValidation": {
+                "Contains": "Please use UseAuthentication() in your Configure method in your Startup class and in your ConfigureServices method in your Startup class use AddAuthentication to set all your various options and middleware as needed.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.json
@@ -1,0 +1,1565 @@
+{
+  "Name": "Microsoft.Owin.Security",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Security",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security",
+      "Value": "Microsoft.Owin.Security",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Remove Microsoft.Owin.Security.OAuth, Microsoft.Owin.Security.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OAuth",
+              "Description": "Remove Microsoft.Owin.Security.OAuth namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OAuth;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security",
+              "Description": "Remove Microsoft.Owin.Security namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "AuthenticationProperties",
+      "Value": "Microsoft.Owin.Security.AuthenticationProperties",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Authentication namespace if AuthenticationProperties is being used and remove Microsoft.Owin.Security.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security",
+              "Description": "Remove Microsoft.Owin.Security namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IAuthenticationManager",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Http namespace and replace IAuthenticationManager with HttpContext.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpContext",
+              "Description": "Replace IAuthenticationManager with HttpContext",
+              "ActionValidation": {
+                "Contains": "HttpContext",
+                "NotContains": "IAuthenticationManager"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.AuthenticateAsync(string[])",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.AuthenticateAsync(string[])",
+      "KeyType": "",
+      "ContainingType": "IAuthenticationManager",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Authentication namespace if AuthenticationProperties is being used and remove Microsoft.Owin.Security.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceParametersOnly",
+              "Type": "Method",
+              "Value": "()",
+              "Description": "Remove parameters of AuthenticateAsync.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "This method does not take a list of string as a parameter, it can only accept a single scheme or no parameters.",
+              "Description": "Add a comment to explain how to use the parameters for the ChallengeAsync api.",
+              "ActionValidation": {
+                "Contains": "Please use your AuthenticationProperties object with this AuthenticateAsync api.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.Challenge(params string[])",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.Challenge(params string[])",
+      "KeyType": "",
+      "ContainingType": "IAuthenticationManager",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Challenge(params string[]) add Microsoft.AspNetCore.Authentication namespace replace Challenge api with ChallengeAsync, remove all parameters and add an await operator. Also adds a comment to explain how to include AuthenticationProperties object and scheme.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "Challenge",
+                "newMethod": "ChallengeAsync",
+                "newParameters": "()"
+              },
+              "Description": "Replace method name from Challenge to ChallengeAsync and remove all parameters.",
+              "ActionValidation": {
+                "Contains": "ChallengeAsync",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please use your AuthenticationProperties object with this ChallengeAsync api if needed. You can also include a scheme.",
+              "Description": "Add a comment to explain how to use the parameters for the ChallengeAsync api.",
+              "ActionValidation": {
+                "Contains": "Please use your AuthenticationProperties object with this ChallengeAsync api if needed. You can also include a scheme.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddAwaitOperator",
+              "Type": "Expression",
+              "Value": "",
+              "Description": "Add the await operator to ChallengeAsync.",
+              "ActionValidation": {
+                "Contains": "await",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.Challenge(Microsoft.Owin.Security.AuthenticationProperties, params string[])",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.Challenge(Microsoft.Owin.Security.AuthenticationProperties, params string[])",
+      "KeyType": "",
+      "ContainingType": "IAuthenticationManager",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Challenge(Microsoft.Owin.Security.AuthenticationProperties, params string[]) add Microsoft.AspNetCore.Authentication namespace replace Challenge api with ChallengeAsync, remove all parameters and add an await operator.. Also adds a comment to explain how to include AuthenticationProperties object and scheme.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "Challenge",
+                "newMethod": "ChallengeAsync",
+                "newParameters": "()"
+              },
+              "Description": "Replace method name from Challenge to ChallengeAsync and remove all parameters.",
+              "ActionValidation": {
+                "Contains": "ChallengeAsync",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please use your AuthenticationProperties object with this ChallengeAsync api if needed. You can also include a scheme.",
+              "Description": "Add a comment to explain how to use the parameters for the ChallengeAsync api.",
+              "ActionValidation": {
+                "Contains": "Please use your AuthenticationProperties object with this ChallengeAsync api if needed. You can also include a scheme.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddAwaitOperator",
+              "Type": "Expression",
+              "Value": "",
+              "Description": "Add the await operator to ChallengeAsync.",
+              "ActionValidation": {
+                "Contains": "await",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.GetAuthenticationTypes()",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.GetAuthenticationTypes()",
+      "KeyType": "",
+      "ContainingType": "IAuthenticationManager",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.GetAuthenticationTypes() add a comment to explain this method has been deprecated.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "This method is now deprecated and most authentication methods can be accessed directly from the HttpContext class through their Microsoft.AspNetCore.Authentication namespace extension.",
+              "Description": "Add a comment to explain this method has been deprecated.",
+              "ActionValidation": {
+                "Contains": "This method is now deprecated and most authentication methods can be accessed directly from the HttpContext class through their Microsoft.AspNetCore.Authentication namespace extension.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.SignIn(params System.Security.Claims.ClaimsIdentity[])",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.SignIn(params System.Security.Claims.ClaimsIdentity[])",
+      "KeyType": "",
+      "ContainingType": "IAuthenticationManager",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.SignIn(params System.Security.Claims.ClaimsIdentity[]) add directive Microsoft.AspNetCore.Authentication, add a comment to explain parameters, add an await operator and replace the method SignIn with SignInAsync.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "SignIn",
+                "newMethod": "SignInAsync"
+              },
+              "Description": "Replace method name from SignIn to SignInAsync and remove all parameters.",
+              "ActionValidation": {
+                "Contains": "SignInAsync",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please use a ClaimsPrincipal object to wrap your list of ClaimsIdentity to pass it to this method as a parameter, you can also include a scheme and an AuthenticationProperties object as well.",
+              "Description": "Add a comment to explain how to use the parameters for the SignInAsync api.",
+              "ActionValidation": {
+                "Contains": "Please use a ClaimsPrincipal object to wrap your list of ClaimsIdentity to pass it to this method as a parameter, you can also include a scheme and an AuthenticationProperties object as well.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddAwaitOperator",
+              "Type": "Expression",
+              "Value": "",
+              "Description": "Add the await operator to SignInAsync.",
+              "ActionValidation": {
+                "Contains": "await",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.SignIn(Microsoft.Owin.Security.AuthenticationProperties, params System.Security.Claims.ClaimsIdentity[])",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.SignIn(Microsoft.Owin.Security.AuthenticationProperties, params System.Security.Claims.ClaimsIdentity[])",
+      "KeyType": "",
+      "ContainingType": "IAuthenticationManager",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.SignIn(Microsoft.Owin.Security.AuthenticationProperties, params System.Security.Claims.ClaimsIdentity[]) add directive Microsoft.AspNetCore.Authentication, add a comment to explain parameters, add an await operator and replace the method SignIn with SignInAsync.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "SignIn",
+                "newMethod": "SignInAsync"
+              },
+              "Description": "Replace method name from SignIn to SignInAsync and remove all parameters.",
+              "ActionValidation": {
+                "Contains": "SignInAsync",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please use a ClaimsPrincipal object to wrap your list of ClaimsIdentity to pass it to this method as a parameter, you can also include a scheme and an AuthenticationProperties object as well.",
+              "Description": "Add a comment to explain how to use the parameters for the SignInAsync api.",
+              "ActionValidation": {
+                "Contains": "Please use a ClaimsPrincipal object to wrap your list of ClaimsIdentity to pass it to this method as a parameter, you can also include a scheme and an AuthenticationProperties object as well.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddAwaitOperator",
+              "Type": "Expression",
+              "Value": "",
+              "Description": "Add the await operator to SignInAsync.",
+              "ActionValidation": {
+                "Contains": "await",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.SignOut(params string[])",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.SignOut(params string[])",
+      "KeyType": "",
+      "ContainingType": "IAuthenticationManager",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.SignOut(params string[]) add directive Microsoft.AspNetCore.Authentication, add a comment to explain parameters, add an await operator and replace the method SignOut with SignOutAsync.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "SignOut",
+                "newMethod": "SignOutAsync",
+                "newParameters": "()"
+              },
+              "Description": "Replace method name from SignOut to SignOutAsync and remove all parameters.",
+              "ActionValidation": {
+                "Contains": "SignOutAsync",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "You can only pass in a single scheme as a parameter and you can also include an AuthenticationProperties object as well.",
+              "Description": "Add a comment to explain how to use the parameters for the SignOutAsync api.",
+              "ActionValidation": {
+                "Contains": "You can only pass in a single scheme as a parameter and you can also include an AuthenticationProperties object as well.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddAwaitOperator",
+              "Type": "Expression",
+              "Value": "",
+              "Description": "Add the await operator to SignOutAsync.",
+              "ActionValidation": {
+                "Contains": "await",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.SignOut(Microsoft.Owin.Security.AuthenticationProperties, params string[])",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.SignOut(Microsoft.Owin.Security.AuthenticationProperties, params string[])",
+      "KeyType": "",
+      "ContainingType": "IAuthenticationManager",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.SignOut(Microsoft.Owin.Security.AuthenticationProperties, params string[]) add directive Microsoft.AspNetCore.Authentication, add a comment to explain parameters, add an await operator and replace the method SignOut with SignOutAsync.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "SignOut",
+                "newMethod": "SignOutAsync",
+                "newParameters": "()"
+              },
+              "Description": "Replace method name from SignOut to SignOutAsync and remove all parameters.",
+              "ActionValidation": {
+                "Contains": "SignOutAsync",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "You can only pass in a single scheme as a parameter and you can also include an AuthenticationProperties object as well.",
+              "Description": "Add a comment to explain how to use the parameters for the SignOutAsync api.",
+              "ActionValidation": {
+                "Contains": "You can only pass in a single scheme as a parameter and you can also include an AuthenticationProperties object as well.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddAwaitOperator",
+              "Type": "Expression",
+              "Value": "",
+              "Description": "Add the await operator to SignOutAsync.",
+              "ActionValidation": {
+                "Contains": "await",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "Microsoft.Owin.Security.AuthenticationTicket",
+      "Value": "Microsoft.Owin.Security.AuthenticationTicket",
+      "KeyType": "Identifier",
+      "ContainingType": "Microsoft.Owin.Security",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.AuthenticationTicket add directive Microsoft.AspNetCore.Authentication.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.Security.AuthenticationTicket.AuthenticationTicket(System.Security.Claims.ClaimsIdentity, Microsoft.Owin.Security.AuthenticationProperties)",
+      "Value": "Microsoft.Owin.Security.AuthenticationTicket.AuthenticationTicket(System.Security.Claims.ClaimsIdentity, Microsoft.Owin.Security.AuthenticationProperties)",
+      "KeyType": "Name",
+      "ContainingType": "AuthenticationTicket",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.AuthenticationTicket.AuthenticationTicket(System.Security.Claims.ClaimsIdentity, Microsoft.Owin.Security.AuthenticationProperties) add directive Microsoft.AspNetCore.Authentication, add a comment to explain the new parameters requirements.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "Please use a ClaimsPrincipal object to wrap your ClaimsIdentity parameter to pass to this method, you can optionally include an AuthenticationProperties object and must include a scheme.",
+              "Description": "Add a comment to explain how to use the parameters for the AuthenticationTicket constructor.",
+              "ActionValidation": {
+                "Contains": "Please use a ClaimsPrincipal object to wrap your list of ClaimsIdentity to pass it to this method as a parameter, you can also include an AuthenticationProperties object and a scheme as well.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.ISecureDataFormat<TData>.Protect(TData)",
+      "Value": "Microsoft.Owin.Security.ISecureDataFormat<TData>.Protect(TData)",
+      "KeyType": "",
+      "ContainingType": "ISecureDataFormat",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.ISecureDataFormat<TData>.Protect(TData) add directive Microsoft.AspNetCore.Authentication.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.ISecureDataFormat<TData>.Unprotect(string)",
+      "Value": "Microsoft.Owin.Security.ISecureDataFormat<TData>.Unprotect(string)",
+      "KeyType": "",
+      "ContainingType": "ISecureDataFormat",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.ISecureDataFormat<TData>.Unprotect(string) add directive Microsoft.AspNetCore.Authentication.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security.OAuth",
+      "Value": "Microsoft.Owin.Security.OAuth",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to setup OAuth in .net core.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Using",
+              "Value": "OAuth is now handled by using the public void ConfigureServices(IServiceCollection services) method in the Startup.cs class. The basic process is to use services.AddAuthentication(options => and then set a series of options. We can chain unto that the actual OAuth settings call services.AddOAuth(\"Auth_Service_here_such_as_GitHub_Canvas...\", options =>. Also remember to add a call to IApplicationBuilder.UseAuthentication() in your public void Configure(IApplicationBuilder app, IHostingEnvironment env) method. Please ensure this call comes before setting up your routes.",
+              "Description": "Add a comment to explain how to setup OAuth in .net core.",
+              "ActionValidation": {
+                "Contains": "OAuth is now handled by using the public void ConfigureServices(IServiceCollection services) method in the Startup.cs class. The basic process is to use services.AddAuthentication(options => and then set a series of options. We can chain unto that the actual OAuth settings call services.AddOAuth(\"Auth_Service_here_such_as_GitHub_Canvas...\", options =>. Also remember to add a call to IApplicationBuilder.UseAuthentication() in your public void Configure(IApplicationBuilder app, IHostingEnvironment env) method. Please ensure this call comes before setting up your routes.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "Microsoft.Owin.Security.AuthenticationDescription",
+      "Value": "Microsoft.Owin.Security.AuthenticationDescription",
+      "KeyType": "Identifier",
+      "ContainingType": "Microsoft.Owin.Security",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace Microsoft.Owin.Security.AuthenticationDescription with Microsoft.AspNetCore.Authentication.AuthenticationScheme.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication",
+              "Description": "Add Microsoft.AspNetCore.Authentication namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "AuthenticationScheme",
+              "Description": "Replace AuthenticationDescription with AuthenticationScheme",
+              "ActionValidation": {
+                "Contains": "AuthenticationScheme",
+                "NotContains": "AuthenticationDescription"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfo()",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfo()",
+      "KeyType": "",
+      "ContainingType": "AuthenticationManagerExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfo() add a comment to explain how to use the SignInManager.GetExternalLoginInfoAsync method to replace the IAuthenticationManager.GetExternalLoginInfo invocation.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the GetExternalLoginInfoAsync method to replace this invocation.",
+              "Description": "Add a comment to explain how to use the SignInManager.GetExternalLoginInfoAsync method to replace the IAuthenticationManager.GetExternalLoginInfo invocation.",
+              "ActionValidation": {
+                "Contains": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the GetExternalLoginInfoAsync method to replace this invocation.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfoAsync()",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfoAsync()",
+      "KeyType": "",
+      "ContainingType": "AuthenticationManagerExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfoAsync() add a comment to explain how to use the SignInManager.GetExternalLoginInfoAsync method to replace the IAuthenticationManager.GetExternalLoginInfoAsync invocation.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the GetExternalLoginInfoAsync method to replace this invocation.",
+              "Description": "Add a comment to explain how to use the SignInManager.GetExternalLoginInfoAsync method to replace the IAuthenticationManager.GetExternalLoginInfoAsync invocation.",
+              "ActionValidation": {
+                "Contains": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the GetExternalLoginInfoAsync method to replace this invocation.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfoAsync(string, string)",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfoAsync(string, string)",
+      "KeyType": "",
+      "ContainingType": "AuthenticationManagerExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.GetExternalLoginInfoAsync(string, string) add a comment to explain how to use the SignInManager.GetExternalLoginInfoAsync(string) method to replace the IAuthenticationManager.GetExternalLoginInfoAsync invocation.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the GetExternalLoginInfoAsync method to replace this invocation.",
+              "Description": "Add a comment to explain how to use the SignInManager.GetExternalLoginInfoAsync(string) method to replace the IAuthenticationManager.GetExternalLoginInfoAsync invocation.",
+              "ActionValidation": {
+                "Contains": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the GetExternalLoginInfoAsync method to replace this invocation.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.GetExternalAuthenticationTypes()",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.GetExternalAuthenticationTypes()",
+      "KeyType": "",
+      "ContainingType": "AuthenticationManagerExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.GetExternalAuthenticationTypes() add a comment to explain how to use the SignInManager.GetExternalAuthenticationSchemesAsync() method to replace the IAuthenticationManager.GetExternalAuthenticationTypes invocation.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the GetExternalAuthenticationSchemesAsync method to replace this invocation.",
+              "Description": "Add a comment to explain how to use the SignInManager.GetExternalAuthenticationSchemesAsync(string) method to replace the IAuthenticationManager.GetExternalAuthenticationTypes invocation.",
+              "ActionValidation": {
+                "Contains": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the GetExternalAuthenticationSchemesAsync method to replace this invocation.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.TwoFactorBrowserRemembered(string)",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.TwoFactorBrowserRemembered(string)",
+      "KeyType": "",
+      "ContainingType": "AuthenticationManagerExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.TwoFactorBrowserRemembered(string) add a comment to explain how to use the SignInManager.IsTwoFactorClientRememberedAsync(TUser) method to replace the IAuthenticationManager.TwoFactorBrowserRemembered invocation.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the TwoFactorBrowserRemembered(TUser) method to replace this invocation.",
+              "Description": "Add a comment to explain how to use the SignInManager.IsTwoFactorClientRememberedAsync(TUser) method to replace the IAuthenticationManager.TwoFactorBrowserRemembered invocation.",
+              "ActionValidation": {
+                "Contains": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the TwoFactorBrowserRemembered(TUser) method to replace this invocation.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.IAuthenticationManager.TwoFactorBrowserRememberedAsync(string)",
+      "Value": "Microsoft.Owin.Security.IAuthenticationManager.TwoFactorBrowserRememberedAsync(string)",
+      "KeyType": "",
+      "ContainingType": "AuthenticationManagerExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.IAuthenticationManager.TwoFactorBrowserRememberedAsync(string) add a comment to explain how to use the SignInManager.IsTwoFactorClientRememberedAsync(TUser) method to replace the IAuthenticationManager.TwoFactorBrowserRememberedAsync invocation.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the TwoFactorBrowserRememberedAsync(TUser) method to replace this invocation.",
+              "Description": "Add a comment to explain how to use the SignInManager.IsTwoFactorClientRememberedAsync(TUser) method to replace the IAuthenticationManager.TwoFactorBrowserRememberedAsync invocation.",
+              "ActionValidation": {
+                "Contains": "You must declare a Microsoft.AspNetCore.Identity.SignInManager<TUser> object and access the TwoFactorBrowserRememberedAsync(TUser) method to replace this invocation.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.notifications.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.notifications.json
@@ -38,7 +38,7 @@
               ]
             }
           ],
-          "Description": "For .Net 5 add Microsoft.AspNetCore.Authentication.OpenIdConnect package and remove Microsoft.Owin.Security.Notifications directive and add Microsoft.AspNetCore.Authentication.OpenIdConnect directive.",
+          "Description": "For .Net 5 and later, add Microsoft.AspNetCore.Authentication.OpenIdConnect package version 5.0.12 and remove Microsoft.Owin.Security.Notifications directive and add Microsoft.AspNetCore.Authentication.OpenIdConnect directive.",
           "Actions": [
             {
               "Name": "AddDirective",
@@ -63,7 +63,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "5.0.12"
+              },
               "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect."
             }
           ]

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.notifications.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.notifications.json
@@ -1,0 +1,233 @@
+{
+  "Name": "Microsoft.Owin.Security.Notifications",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Security.Notifications",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security.Notifications",
+      "Value": "Microsoft.Owin.Security.Notifications",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For .Net 5 add Microsoft.AspNetCore.Authentication.OpenIdConnect package and remove Microsoft.Owin.Security.Notifications directive and add Microsoft.AspNetCore.Authentication.OpenIdConnect directive.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.Notifications",
+              "Description": "Remove Microsoft.Owin.Security.Notifications namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.Notifications;"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect."
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For .Net Core add Microsoft.AspNetCore.Authentication.OpenIdConnect package version 3.1.18 and remove Microsoft.Owin.Security.Notifications directive and add Microsoft.AspNetCore.Authentication.OpenIdConnect directive.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.Notifications",
+              "Description": "Remove Microsoft.Owin.Security.Notifications namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.Notifications;"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "3.1.18"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect version 3.1.18"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.Notifications.RedirectToIdentityProviderNotification<TMessage, TOptions>.HandleResponse()",
+      "Value": "Microsoft.Owin.Security.Notifications.RedirectToIdentityProviderNotification<TMessage, TOptions>.HandleResponse()",
+      "KeyType": "",
+      "ContainingType": "RedirectToIdentityProviderNotification",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.Notifications.RedirectToIdentityProviderNotification<TMessage, TOptions>.HandleResponse() add a comment to explain how to replace the class RedirectToIdentityProviderNotification with RedirectContext class.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace RedirectToIdentityProviderNotification with RedirectContext. The constructor for this new class takes the following parameters: new RedirectContext(HttpContext, AuthenticationScheme, OpenIdConnectOptions, AuthenticationProperties);",
+              "Description": "Add a comment to explain how to replace the RedirectToIdentityProviderNotification class with the RedirectContext class.",
+              "ActionValidation": {
+                "Contains": "Please replace RedirectToIdentityProviderNotification with RedirectContext. The constructor for this new class takes the following parameters: new RedirectContext(HttpContext, AuthenticationScheme, OpenIdConnectOptions, AuthenticationProperties);",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Security.Notifications.BaseNotification<TOptions>.HandleResponse()",
+      "Value": "Microsoft.Owin.Security.Notifications.BaseNotification<TOptions>.HandleResponse()",
+      "KeyType": "",
+      "ContainingType": "BaseNotification",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For Microsoft.Owin.Security.Notifications.BaseNotification<TOptions>.HandleResponse() add a comment to explain how to replace the class BaseNotification.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace BaseNotification with a class from the Microsoft.AspNetCore.Authentication.OpenIdConnect namespace. The MessageReceivedContext class is a good candidate. Its constructor takes the following parameters: new MessageReceivedContext(HttpContext, AuthenticationScheme, OpenIdConnectOptions, AuthenticationProperties);",
+              "Description": "Add a comment to explain how to replace the BaseNotification class.",
+              "ActionValidation": {
+                "Contains": "Please replace BaseNotification with a class from the Microsoft.AspNetCore.Authentication.OpenIdConnect namespace. The MessageReceivedContext class is a good candidate. Its constructor takes the following parameters: new MessageReceivedContext(HttpContext, AuthenticationScheme, OpenIdConnectOptions, AuthenticationProperties);",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.openidconnect.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.openidconnect.json
@@ -38,7 +38,7 @@
               ]
             }
           ],
-          "Description": "For .Net 5 add latest Microsoft.AspNetCore.Authentication.Google package and add a comment to explain how to add google authentication.",
+          "Description": "For .Net 5 and later, add Microsoft.AspNetCore.Authentication.OpenIdConnect package version 5.0.12",
           "Actions": [
             {
               "Name": "AddDirective",
@@ -63,7 +63,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "5.0.12"
+              },
               "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect."
             }
           ]
@@ -82,7 +85,7 @@
               ]
             }
           ],
-          "Description": "For .Net Core add Microsoft.AspNetCore.Authentication.Google package version 3.1.18 and add a comment to explain how to add google authentication.",
+          "Description": "For .Net Core add Microsoft.AspNetCore.Authentication.OpenIdConnect package version 3.1.18.",
           "Actions": [
             {
               "Name": "AddDirective",

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.openidconnect.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.security.openidconnect.json
@@ -1,0 +1,176 @@
+{
+  "Name": "Microsoft.Owin.Security.OpenIdConnect",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.Security.OpenIdConnect",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Microsoft.Owin.Security.OpenIdConnect",
+      "Value": "Microsoft.Owin.Security.OpenIdConnect",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For .Net 5 add latest Microsoft.AspNetCore.Authentication.Google package and add a comment to explain how to add google authentication.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect."
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For .Net Core add Microsoft.AspNetCore.Authentication.Google package version 3.1.18 and add a comment to explain how to add google authentication.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "3.1.18"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect version 3.1.18"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "OpenIdConnectAuthenticationOptions",
+      "Value": "Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions",
+      "KeyType": "Identifier",
+      "ContainingType": "OpenIdConnectAuthenticationOptions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace OpenIdConnectAuthenticationOptions with OpenIdConnectOptions.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "OpenIdConnectOptions",
+              "Description": "Replace OpenIdConnectAuthenticationOptions with OpenIdConnectOptions",
+              "ActionValidation": {
+                "Contains": "OpenIdConnectOptions",
+                "NotContains": "OpenIdConnectAuthenticationOptions"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/microsoft.owin.staticfiles.json
+++ b/tst/CTA.Rules.Test/TempRules/microsoft.owin.staticfiles.json
@@ -1,0 +1,275 @@
+{
+  "Name": "Microsoft.Owin.StaticFiles",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.StaticFiles",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "StaticFiles",
+      "Value": "Microsoft.Owin.StaticFiles",
+      "KeyType": "Method",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.StaticFiles and Microsoft.Extensions.FileProviders.Physical packages. Add Microsoft.Extensions.FileProviders and Microsoft.AspNetCore.StaticFiles namespaces. Remove Microsoft.Owin.StaticFiles and Microsoft.Owin.FileSystems namespaces.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.StaticFiles",
+              "Description": "Add package Microsoft.AspNetCore.StaticFiles"
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.Extensions.FileProviders.Physical",
+              "Description": "Add package Microsoft.Extensions.FileProviders.Physical"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.FileProviders",
+              "Description": "Add Microsoft.Extensions.FileProviders",
+              "ActionValidation": {
+                "Contains": "using Microsoft.Extensions.FileProviders;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.StaticFiles",
+              "Description": "Add Microsoft.AspNetCore.StaticFiles",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.StaticFiles;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.StaticFiles",
+              "Description": "Remove Microsoft.Owin.StaticFiles namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.StaticFiles;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.FileSystems",
+              "Description": "Remove Microsoft.Owin.FileSystems namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.FileSystems;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.StaticFiles.FileServerOptions.FileServerOptions()",
+      "Value": "Microsoft.Owin.StaticFiles.FileServerOptions.FileServerOptions()",
+      "KeyType": "Name",
+      "ContainingType": "FileServerOptions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace FileServerOptions' FileSystem with FileProvider and PhysicalFileSystem with PhysicalFileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceOrAddObjectPropertyIdentifier",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "FileSystem",
+                "newMember": "FileProvider",
+                "newValueIfAdding": "new PhysicalFileProvider(@\"\")"
+              },
+              "Description": "Replace FileServerOptions' FileSystem with FileProvider",
+              "ActionValidation": {
+                "Contains": "FileProvider",
+                "NotContains": "FileSystem"
+              }
+            },
+            {
+              "Name": "ReplaceObjectPropertyValue",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "PhysicalFileSystem",
+                "newMember": "PhysicalFileProvider"
+              },
+              "Description": "Replace FileServerOptions' PhysicalFileSystem with PhysicalFileProvider",
+              "ActionValidation": {
+                "Contains": "PhysicalFileProvider",
+                "NotContains": "PhysicalFileSystem"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "For FileServerOptions, if FileSystem was not present before FileProvider was added, please initialize this new value. Using the value from RequestPath with System.IO.Directory.GetCurrentDirectory() as a prefix may be a good starting point.",
+              "Description": "Add a comment to explain how to initialize FileProvider correctly for FileServerOptions.",
+              "ActionValidation": {
+                "Contains": "For FileServerOptions, if FileSystem was not present before FileProvider was added, please initialize this new value.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.StaticFiles.DirectoryBrowserOptions.DirectoryBrowserOptions()",
+      "Value": "Microsoft.Owin.StaticFiles.DirectoryBrowserOptions.DirectoryBrowserOptions()",
+      "KeyType": "Name",
+      "ContainingType": "DirectoryBrowserOptions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace DirectoryBrowserOptions' FileSystem with FileProvider and PhysicalFileSystem with PhysicalFileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceOrAddObjectPropertyIdentifier",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "FileSystem",
+                "newMember": "FileProvider",
+                "newValueIfAdding": "new PhysicalFileProvider(@\"\")"
+              },
+              "Description": "Replace DirectoryBrowserOptions' FileSystem with FileProvider",
+              "ActionValidation": {
+                "Contains": "FileProvider",
+                "NotContains": "FileSystem"
+              }
+            },
+            {
+              "Name": "ReplaceObjectPropertyValue",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "PhysicalFileSystem",
+                "newMember": "PhysicalFileProvider"
+              },
+              "Description": "Replace DirectoryBrowserOptions' PhysicalFileSystem with PhysicalFileProvider",
+              "ActionValidation": {
+                "Contains": "PhysicalFileProvider",
+                "NotContains": "PhysicalFileSystem"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "For DirectoryBrowserOptions, if FileSystem was not present before FileProvider was added, please initialize this new value. Using the value from RequestPath with System.IO.Directory.GetCurrentDirectory() as a prefix may be a good starting point.",
+              "Description": "Add a comment to explain how to initialize FileProvider correctly for DirectoryBrowserOptions.",
+              "ActionValidation": {
+                "Contains": "For DirectoryBrowserOptions, if FileSystem was not present before FileProvider was added, please initialize this new value.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -805,7 +805,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "5.0.12"
+              },
               "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect"
             },
             {
@@ -964,7 +967,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "5.0.12"
+              },
               "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect"
             },
             {
@@ -1093,7 +1099,7 @@
               ]
             }
           ],
-          "Description": "For .Net 5 add latest Microsoft.AspNetCore.Authentication.Google package and add a comment to explain how to add google authentication.",
+          "Description": "For .Net 5 and later, add Microsoft.AspNetCore.Authentication.Google package version 5.0.12 and add a comment to explain how to add google authentication.",
           "Actions": [
             {
               "Name": "AddComment",
@@ -1109,7 +1115,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": "Microsoft.AspNetCore.Authentication.Google",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.Google",
+                "Value": "5.0.12" 
+              },
               "Description": "Add package Microsoft.AspNetCore.Authentication.Google"
             },
             {

--- a/tst/CTA.Rules.Test/TempRules/owin.json
+++ b/tst/CTA.Rules.Test/TempRules/owin.json
@@ -1,0 +1,1178 @@
+{
+  "Name": "Owin",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Owin",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Class",
+      "Name": "IAppBuilder",
+      "Value": "Owin.IAppBuilder",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace IAppBuilder with IApplicationBuilder and add the Microsoft.AspNetCore.Builder namespace and the Microsoft.AspNetCore.Diagnostics package and remove the Owin namespace.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Diagnostics",
+              "Description": "Add package Microsoft.AspNetCore.Diagnostics"
+            },
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IApplicationBuilder",
+              "Description": "Replace IAppBuilder with IApplicationBuilder",
+              "ActionValidation": {
+                "Contains": "IApplicationBuilder",
+                "NotContains": "IAppBuilder"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Owin",
+              "Description": "Remove Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Owin;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.Use(object, params object[])",
+      "Value": "Owin.IAppBuilder.Use(object, params object[])",
+      "KeyType": "Name",
+      "ContainingType": "IAppBuilder",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace Owin.IAppBuilder.Use(object, params object[]) with .UseOwin.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "Use",
+                "newMethod": "UseOwin",
+                "newParameters": "(pipeline => { pipeline(next => Invoke); })"
+              },
+              "Description": "Replace Use(object, params object[]) with UseOwin",
+              "ActionValidation": {
+                "Contains": "UseOwin",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Invoke being the function you wanted to call in your lambda function.",
+              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use(object, params object[]) to UseOwin.",
+              "ActionValidation": {
+                "Contains": "Invoke being the function you wanted to call in your lambda function.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.Use<T>(params object[])",
+      "Value": "Owin.IAppBuilder.Use<T>(params object[])",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderUseExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace Owin.IAppBuilder.Use<T>(params object[]) with .UseMiddleware<MiddlewareNameHere>.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "Use",
+                "newMethod": "UseMiddleware"
+              },
+              "Description": "Replace Owin.IAppBuilder.Use<T>(params object[]) with UseMiddleware",
+              "ActionValidation": {
+                "Contains": "UseMiddleware",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseWebApi(System.Web.Http.HttpConfiguration)",
+      "Value": "Owin.IAppBuilder.UseWebApi(System.Web.Http.HttpConfiguration)",
+      "KeyType": "Name",
+      "ContainingType": "WebApiAppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseWebApi",
+                "newMethod": "UseEndpoints",
+                "newParameters": "(endpoints => { endpoints.MapControllers(); })"
+              },
+              "Description": "Replace UseWebApi with UseEndpoints",
+              "ActionValidation": {
+                "Contains": "UseEndpoints",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddControllers(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddControllers(); }",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Http",
+              "Description": "Remove System.Web.Http namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Http;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.MapSignalR()",
+      "Value": "Owin.IAppBuilder.MapSignalR()",
+      "KeyType": "Name",
+      "ContainingType": "OwinExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.SignalR package and replace MapSignalR with UseEndpoints. Add a comment to add a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.SignalR",
+              "Description": "Add package Microsoft.AspNetCore.SignalR"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Builder",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Builder;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.SignalR",
+              "Description": "Add Microsoft.AspNetCore.SignalR namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.SignalR;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "MapSignalR",
+                "newMethod": "UseEndpoints",
+                "newParameters": "(routes => routes.MapHub<Hub>(\"pattern\"))"
+              },
+              "Description": "Replace MapSignalR with UseEndpoints",
+              "ActionValidation": {
+                "Contains": "UseEndpoints",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddSignalR(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddSignalR(); }",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseErrorPage()",
+      "Value": "Owin.IAppBuilder.UseErrorPage()",
+      "KeyType": "Name",
+      "ContainingType": "ErrorPageExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace UseErrorPage with UseDeveloperExceptionPage.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseErrorPage",
+                "newMethod": "UseDeveloperExceptionPage"
+              },
+              "Description": "Replace UseErrorPage with UseDeveloperExceptionPage",
+              "ActionValidation": {
+                "Contains": "UseDeveloperExceptionPage",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseDirectoryBrowser(Microsoft.Owin.StaticFiles.DirectoryBrowserOptions)",
+      "Value": "Owin.IAppBuilder.UseDirectoryBrowser(Microsoft.Owin.StaticFiles.DirectoryBrowserOptions)",
+      "KeyType": "Name",
+      "ContainingType": "DirectoryBrowserExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add Microsoft.Extensions.DependencyInjection namespace. Add a comment to add ConfigureServices method and explain how to use FileProvider attribute inside of DirectoryBrowsingOptions class.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.DependencyInjection",
+              "Description": "Add Microsoft.AspNetCore.Builder namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.Extensions.DependencyInjection;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddDirectoryBrowser(); }",
+              "Description": "Add a comment on adding a new configureservices method.",
+              "ActionValidation": {
+                "Contains": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddDirectoryBrowser(); }",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<T>)",
+      "Value": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<T>)",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<T>) with a service in ConfigureServices method.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNet.Identity.Owin",
+              "Description": "Remove Microsoft.AspNet.Identity.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.AspNet.Identity.Owin;"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace CreatePerOwinContext<T>(System.Func<T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }. For example, app.CreatePerOwinContext(ApplicationDbContext.Create); would become: services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(config.GetConnectionString(\"DefaultConnection\"))); ",
+              "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<T>) with a service in ConfigureServices method.",
+              "ActionValidation": {
+                "Contains": "Please replace CreatePerOwinContext<T>(System.Func<T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>)",
+      "Value": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>)",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>) with a service in ConfigureServices method.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNet.Identity.Owin",
+              "Description": "Remove Microsoft.AspNet.Identity.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.AspNet.Identity.Owin;"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }. For example, app.CreatePerOwinContext(ApplicationDbContext.Create); would become: services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(config.GetConnectionString(\"DefaultConnection\"))); ",
+              "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>) with a service in ConfigureServices method.",
+              "ActionValidation": {
+                "Contains": "Please replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>)",
+      "Value": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>)",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>) with a service in ConfigureServices method.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNet.Identity.Owin",
+              "Description": "Remove Microsoft.AspNet.Identity.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.AspNet.Identity.Owin;"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }. For example, app.CreatePerOwinContext(ApplicationDbContext.Create); would become: services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(config.GetConnectionString(\"DefaultConnection\"))); ",
+              "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>) with a service in ConfigureServices method.",
+              "ActionValidation": {
+                "Contains": "Please replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(string, string)",
+      "Value": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(string, string)",
+      "KeyType": "Name",
+      "ContainingType": "OpenIdConnectAuthenticationExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "3.1.15"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect version 3.1.15"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions)",
+      "Value": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions)",
+      "KeyType": "Name",
+      "ContainingType": "OpenIdConnectAuthenticationExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "3.1.15"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect version 3.1.15"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseGoogleAuthentication(Microsoft.Owin.Security.Google.GoogleOAuth2AuthenticationOptions)",
+      "Value": "Owin.IAppBuilder.UseGoogleAuthentication(Microsoft.Owin.Security.Google.GoogleOAuth2AuthenticationOptions)",
+      "KeyType": "Name",
+      "ContainingType": "GoogleAuthenticationExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For .Net 5 add latest Microsoft.AspNetCore.Authentication.Google package and add a comment to explain how to add google authentication.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add IApplicationBuilder.UseAuthentication() in your configure method. Within your public void ConfigureServices(IServiceCollection services) method please add services.AddAuthentication().AddGoogle(options => { IConfigurationSection googleAuthNSection = Configuration.GetSection(\"Authentication:Google\"); options.ClientId = googleAuthNSection[\"ClientId\"]; options.ClientSecret = googleAuthNSection[\"ClientSecret\"]; } );",
+              "Description": "Add a comment to explain how to add google authentication.",
+              "ActionValidation": {
+                "Contains": "Please add IApplicationBuilder.UseAuthentication() in your configure method. Within your public void ConfigureServices(IServiceCollection services) method please add services.AddAuthentication().AddGoogle(options => { IConfigurationSection googleAuthNSection = Configuration.GetSection(\"Authentication:Google\"); options.ClientId = googleAuthNSection[\"ClientId\"]; options.ClientSecret = googleAuthNSection[\"ClientSecret\"]; } );",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.Google",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.Google"
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.Google",
+              "Description": "Remove Microsoft.Owin.Security.Google",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.Google;"
+              }
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "For .Net Core add Microsoft.AspNetCore.Authentication.Google package version 3.1.18 and add a comment to explain how to add google authentication.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add IApplicationBuilder.UseAuthentication() in your configure method. Within your public void ConfigureServices(IServiceCollection services) method please add services.AddAuthentication().AddGoogle(options => { IConfigurationSection googleAuthNSection = Configuration.GetSection(\"Authentication:Google\"); options.ClientId = googleAuthNSection[\"ClientId\"]; options.ClientSecret = googleAuthNSection[\"ClientSecret\"]; } );",
+              "Description": "Add a comment to explain how to add google authentication.",
+              "ActionValidation": {
+                "Contains": "Please add IApplicationBuilder.UseAuthentication() in your configure method. Within your public void ConfigureServices(IServiceCollection services) method please add services.AddAuthentication().AddGoogle(options => { IConfigurationSection googleAuthNSection = Configuration.GetSection(\"Authentication:Google\"); options.ClientId = googleAuthNSection[\"ClientId\"]; options.ClientSecret = googleAuthNSection[\"ClientSecret\"]; } );",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.Google",
+                "Version": "3.1.18"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.Google version 3.1.18"
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.Google",
+              "Description": "Remove Microsoft.Owin.Security.Google",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.Google;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/project.all.json
+++ b/tst/CTA.Rules.Test/TempRules/project.all.json
@@ -1,0 +1,109 @@
+{
+  "Name": "Project",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Project",
+      "Type": "Project"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Project",
+      "Name": "Project",
+      "Value": "Project",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netstandard2.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "",
+          "Actions": [
+            {
+              "Name": "MigrateConfig",
+              "Type": "Project",
+              "Value": "",
+              "Description": "Migrate settings from web.config file to appsettings.json."
+            },
+            {
+              "Name": "MigrateProjectFile",
+              "Type": "ProjectFile",
+              "Value": "",
+              "Description": "Migrate csproj file to core"
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "",
+          "Actions": [
+            {
+              "Name": "ArchiveFiles",
+              "Type": "Project",
+              "Value": "BundleConfig.cs,FilterConfig.cs,RouteConfig.cs,WebApiConfig.cs,global.asax.cs,global.asax,AssemblyInfo.cs,packages.config",
+              "Description": "Archive files that are no longer used in core projects."
+            },
+            {
+              "Name": "CreateNetCoreFolderHierarchy",
+              "Type": "Project",
+              "Value": "",
+              "Description": "Create folder hierarchy based on type of project\r\nCreated Startup.cs and Program.cs files based on type of project"
+            },
+            {
+              "Name": "MigrateConfig",
+              "Type": "Project",
+              "Value": "",
+              "Description": "Migrate settings from web.config file to appsettings.json."
+            },
+            {
+              "Name": "MigrateProjectFile",
+              "Type": "ProjectFile",
+              "Value": "",
+              "Description": "Migrate csproj file to core"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.collections.specialized.json
+++ b/tst/CTA.Rules.Test/TempRules/system.collections.specialized.json
@@ -1,0 +1,120 @@
+{
+  "Name": "System.Collections.Specialized",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Collections.Specialized",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "ElementAccess",
+      "Name": "ConfigurationManager.AppSettings",
+      "Value": "System.Collections.Specialized.NameValueCollection.ConfigurationManager.AppSettings",
+      "ContainingType": "NameValueCollection",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Update configuration to retrieve connection string from appSettings.json file.",
+          "Actions": [
+            {
+              "Name": "ReplaceElementAccess",
+              "Type": "ElementAccess",
+              "Value": "ConfigurationManager.Configuration.GetSection(\"appSettings\")",
+              "Description": "Update configuration to retrieve connection string from appSettings.json file.",
+              "ActionValidation": {
+                "Contains": "ConfigurationManager.Configuration.GetSection",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ElementAccess",
+      "Name": "WebConfigurationManager.AppSettings",
+      "Value": "System.Collections.Specialized.NameValueCollection.WebConfigurationManager.AppSettings",
+      "ContainingType": "NameValueCollection",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Update configuration to retrieve appSettings from appSettings.json file.",
+          "Actions": [
+            {
+              "Name": "ReplaceElementAccess",
+              "Type": "ElementAccess",
+              "Value": "ConfigurationManager.Configuration.GetSection(\"appSettings\")",
+              "Description": "Update configuration to retrieve appSettings from appSettings.json file.",
+              "ActionValidation": {
+                "Contains": "ConfigurationManager.Configuration.GetSection",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.configuration.json
+++ b/tst/CTA.Rules.Test/TempRules/system.configuration.json
@@ -1,0 +1,126 @@
+{
+  "Name": "System.Configuration",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Configuration",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "ElementAccess",
+      "Name": "ConfigurationManager.ConnectionStrings",
+      "Value": "System.Configuration.ConnectionStringSettingsCollection.ConfigurationManager.ConnectionStrings",
+      "ContainingType": "ConnectionStringSettingsCollection",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Update configuration to retrieve connection string from appSettings.json file.",
+          "Actions": [
+            {
+              "Name": "ReplaceElementAccess",
+              "Type": "ElementAccess",
+              "Value": "ConfigurationManager.Configuration.GetSection(\"ConnectionStrings\")",
+              "Description": "Update configuration to retrieve connection string from appSettings.json file.",
+              "ActionValidation": {
+                "Contains": "ConfigurationManager.Configuration.GetSection",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Configuration",
+              "Description": "Remove System.Configuration namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Configuration;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "MemberAccess",
+      "Name": "ConnectionString",
+      "Value": "System.Configuration.ConnectionStringSettings.ConnectionString",
+      "ContainingType": "ConnectionStringSettings",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Remove ConnectionString accessor.",
+          "Actions": [
+            {
+              "Name": "RemoveMemberAccess",
+              "Type": "MemberAccess",
+              "Value": "",
+              "Description": "Remove ConnectionString accessor."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.data.entity.json
+++ b/tst/CTA.Rules.Test/TempRules/system.data.entity.json
@@ -61,7 +61,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": "Microsoft.EntityFrameworkCore",
+              "Value": {
+                "Name": "Microsoft.EntityFrameworkCore",
+                "Version": "5.0.12"
+              },
               "Description": "Add reference to Microsoft.EntityFrameworkCore."
             },
             {

--- a/tst/CTA.Rules.Test/TempRules/system.data.entity.json
+++ b/tst/CTA.Rules.Test/TempRules/system.data.entity.json
@@ -1,0 +1,176 @@
+{
+  "Name": "System.Data.Entity",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "EntityFramework",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.Data.Entity",
+      "Value": "System.Data.Entity",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netstandard2.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.Data.Entity namespace with Microsoft.EntityFrameworkCore. Also, package Microsoft.EntityFrameworkCore will be added.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.EntityFrameworkCore",
+              "Description": "Add reference to Microsoft.EntityFrameworkCore."
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.EntityFrameworkCore",
+              "Description": "Add Microsoft.EntityFrameworkCore namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.EntityFrameworkCore;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Data.Entity",
+              "Description": "Remove System.Data.Entity namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Data.Entity;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "DbContext",
+      "Value": "System.Data.Entity.DbContext",
+      "KeyType": "BaseClass",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netstandard2.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add an OnConfiguring method to set the connection string. In addition, System.Data.Entity namespace will be replaced with Microsoft.EntityFrameworkCore.",
+          "Actions": [
+            {
+              "Name": "AddMethod",
+              "Type": "Class",
+              "Value": "protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) { /* Use Configuration from static ConfigurationManager to access connection string in appsettings.json. Example below: optionsBuilder.UseSqlServer(ConfigurationManager.Configuration.GetConnectionString(\"CONNECTIONSTRINGNAME\")); */ base.OnConfiguring(optionsBuilder); }",
+              "Description": "Add a method to configure the connection string.",
+              "ActionValidation": {
+                "Contains": "OnConfiguring(DbContextOptionsBuilder",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.EntityFrameworkCore",
+              "Description": "Add Microsoft.EntityFrameworkCore namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.EntityFrameworkCore;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Data.Entity",
+              "Description": "Remove System.Data.Entity namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Data.Entity;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.data.sqlclient.json
+++ b/tst/CTA.Rules.Test/TempRules/system.data.sqlclient.json
@@ -1,0 +1,92 @@
+{
+  "Name": "System.Data.SqlClient",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Data",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.Data.SqlClient",
+      "Value": "System.Data.SqlClient",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netstandard2.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add the package Microsoft.Data.SqlClient to the project. In addition, System.Data.SqlClient namespace will be replaced with Microsoft.Data.SqlClient.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.Data.SqlClient",
+              "Description": "Add reference to Microsoft.Data.SqlClient."
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Data.SqlClient",
+              "Description": "Add Microsoft.Data.SqlClient namespace.",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Data.SqlClient;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Data.SqlClient",
+              "Description": "Remove System.Data.SqlClient namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingSystem.Data.SqlClient;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.runtime.caching.json
+++ b/tst/CTA.Rules.Test/TempRules/system.runtime.caching.json
@@ -61,7 +61,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": "System.Runtime.Caching",
+              "Value": {
+                "Name": "System.Runtime.Caching",
+                "Version": "5.0.0"
+              },
               "Description": "Add System.Runtime.Caching package"
             }
           ]

--- a/tst/CTA.Rules.Test/TempRules/system.runtime.caching.json
+++ b/tst/CTA.Rules.Test/TempRules/system.runtime.caching.json
@@ -1,0 +1,72 @@
+{
+  "Name": "System.Runtime.Caching",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Runtime.Caching",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.Runtime.Caching",
+      "Value": "System.Runtime.Caching",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netstandard2.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add System.Runtime.Caching package",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "System.Runtime.Caching",
+              "Description": "Add System.Runtime.Caching package"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.web.configuration.json
+++ b/tst/CTA.Rules.Test/TempRules/system.web.configuration.json
@@ -1,0 +1,126 @@
+{
+  "Name": "System.Web.Configuration",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Web.Configuration",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "ElementAccess",
+      "Name": "WebConfigurationManager.ConnectionStrings",
+      "Value": "System.Configuration.ConnectionStringSettingsCollection.WebConfigurationManager.ConnectionStrings",
+      "ContainingType": "ConnectionStringSettingsCollection",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "",
+          "Actions": [
+            {
+              "Name": "ReplaceElementAccess",
+              "Type": "ElementAccess",
+              "Value": "ConfigurationManager.Configuration.GetSection(\"ConnectionStrings\")",
+              "Description": "Update configuration to retrieve connection string from appSettings.json file.",
+              "ActionValidation": {
+                "Contains": "ConfigurationManager.Configuration.GetSection",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Configuration",
+              "Description": "Remove System.Web.Configuration namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Configuration;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "MemberAccess",
+      "Name": "ConnectionString",
+      "Value": "System.Configuration.ConnectionStringSettings.ConnectionString",
+      "ContainingType": "ConnectionStringSettings",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Remove ConnectionString accessor.",
+          "Actions": [
+            {
+              "Name": "RemoveMemberAccess",
+              "Type": "MemberAccess",
+              "Value": "",
+              "Description": "Remove ConnectionString accessor."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.web.http.json
+++ b/tst/CTA.Rules.Test/TempRules/system.web.http.json
@@ -1,0 +1,238 @@
+{
+  "Name": "System.Web.Http",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Web.Http",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Attribute",
+      "Name": "RoutePrefix",
+      "Value": "System.Web.Http.RoutePrefixAttribute.RoutePrefixAttribute(string)",
+      "KeyType": "Name",
+      "ContainingType": "RoutePrefixAttribute",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment: RoutePrefix attribute is no longer supported.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "AttributeList",
+              "Value": "RoutePrefix attribute is no longer supported",
+              "Description": "RoutePrefix attribute is no longer supported",
+              "ActionValidation": {
+                "Contains": "RoutePrefix attribute is no longer supported",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IHttpActionResult",
+      "Value": "System.Web.Http.IHttpActionResult",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace IHttpActionResult in namespace System.Web.Http with IActionResult in namespace Microsoft.AspNetCore.Mvc.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IActionResult",
+              "Description": "Replace IHttpActionResult with IActionResult.",
+              "ActionValidation": {
+                "Contains": "IActionResult",
+                "NotContains": "IHttpActionResult"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Http",
+              "Description": "Remove System.Web.Http namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Http;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "ApiController",
+      "Value": "System.Web.Http.ApiController",
+      "KeyType": "BaseClass",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace base class ApiController in namespace System.Web with ControllerBase in namespace Microsoft.AspNetCore.Mvc. In addition, attribute ApiController will be added to the class.",
+          "Actions": [
+            {
+              "Name": "RemoveBaseClass",
+              "Type": "Class",
+              "Value": "ApiController",
+              "Description": "Removes base class ApiController.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ":ApiController"
+              }
+            },
+            {
+              "Name": "AddBaseClass",
+              "Type": "Class",
+              "Value": "ControllerBase",
+              "Description": "Add base class ControllerBase.",
+              "ActionValidation": {
+                "Contains": "ControllerBase",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddAttribute",
+              "Type": "Class",
+              "Value": "ApiController",
+              "Description": "Add attribute ApiController.",
+              "ActionValidation": {
+                "Contains": "[ApiController]",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Http",
+              "Description": "Remove System.Web.Http namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Http;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.web.http.odata.json
+++ b/tst/CTA.Rules.Test/TempRules/system.web.http.odata.json
@@ -1,0 +1,83 @@
+{
+  "Name": "System.Web.Http.OData",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Web.Http.OData",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Attribute",
+      "Name": "EnableQuery",
+      "Value": "System.Web.Http.OData.EnableQueryAttribute.EnableQueryAttribute()",
+      "KeyType": "Name",
+      "ContainingType": "EnableQueryAttribute",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.Web.Http.OData namespace with Microsoft.AspNet.OData. In addition, package Microsoft.AspNetCore.OData will be added to the project file.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Http.OData",
+              "Description": "Remove System.Web.Http.OData namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Http.OData;"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.OData.Query",
+              "Description": "Add Microsoft.AspNetCore.OData.Query namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.OData.Query;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.OData",
+              "Description": "Add reference to Microsoft.AspNetCore.OData."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.web.json
+++ b/tst/CTA.Rules.Test/TempRules/system.web.json
@@ -1,0 +1,218 @@
+{
+  "Name": "System.Web",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Web",
+      "Type": "SDK"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Method",
+      "Name": "System.Web.HttpResponse.AppendHeader(string, string)",
+      "Value": "System.Web.HttpResponse.AppendHeader(string, string)",
+      "KeyType": "Name",
+      "ContainingType": "HttpResponse",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace method AppendHeader with this.Response.Headers.Add. In the replacement, \"this\" refers to the controller object.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodWithObject",
+              "Type": "Method",
+              "Value": "this.Response.Headers.Add",
+              "Description": "Replace AppendHeader with a new method to add to headers.",
+              "ActionValidation": {
+                "Contains": "this.Response.Headers.Add",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "In this context, this is a Controller object",
+              "Description": "Add a comment to explain what \"this\" refers to.",
+              "ActionValidation": {
+                "Contains": "In this context, this is a Controller object",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
+      "Value": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
+      "KeyType": "Name",
+      "ContainingType": "HttpServerUtilityBase",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace HtmlEncode with a new method HtmlEncoder.Default.Encode in namepsace System.Text.Encodings.Web.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodWithObject",
+              "Type": "Method",
+              "Value": "HtmlEncoder.Default.Encode",
+              "Description": "Replace HtmlEncode with a new method: HtmlEncoder.Default.Encode.",
+              "ActionValidation": {
+                "Contains": "HtmlEncoder.Default.Encode",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "System.Text.Encodings.Web",
+              "Description": "Add System.Text.Encodings.Web.",
+              "ActionValidation": {
+                "Contains": "using System.Text.Encodings.Web;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "HttpContextBase",
+      "Value": "System.Web.HttpContextBase",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace HttpContextBase in namespace System.Web with HttpContext in namespace Microsoft.AspNetCore.Http.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "HttpContext",
+              "Description": "Replace HttpContextBase with HttpContext.",
+              "ActionValidation": {
+                "Contains": "HttpContext",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web",
+              "Description": "Remove System.Web namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/system.web.mvc.json
+++ b/tst/CTA.Rules.Test/TempRules/system.web.mvc.json
@@ -1,0 +1,1002 @@
+{
+  "Name": "System.Web.Mvc",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "System.Web.Mvc",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "System.Web.Mvc",
+      "Value": "System.Web.Mvc",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Attribute",
+      "Name": "ChildActionOnly",
+      "Value": "System.Web.Mvc.ChildActionOnlyAttribute.ChildActionOnlyAttribute()",
+      "KeyType": "Name",
+      "ContainingType": "ChildActionOnlyAttribute",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment: ChildActionOnly attribute is not available anymore. An alternative is using ViewComponents. Sample code will be added as an example.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "AttributeList",
+              "Value": "This attribute is not available anymore. An alternative is using ViewComponents:\nSample:\n\npublic class SampleViewComponent : ViewComponent\n    {\n        private readonly InjectedService _injectedService;\n\n        public SampleViewComponent (InjectedService injectedService)\n        {\n            _injectedService = injectedService;\n        }\n\n\n       public IViewComponentResult Invoke(int parameter)\n        {\n            var object = _injectedService.SampleFunction(parameter);\n        // No name is specified, returns the view SampleView (same name as component)\n            return View(object);\n        }\n    }\n\nThen use this to call the view component from any view:\n\n    @await Component.InvokeAsync(\"SampleView\", new { parameter = \"\"})\n\nhttps://docs.microsoft.com/en-us/aspnet/core/mvc/views/view-components?view=aspnetcore-3.1",
+              "Description": "ChildActionOnly attribute is not available anymore.",
+              "ActionValidation": {
+                "Contains": "ViewComponents:",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Attribute",
+      "Name": "AllowAnonymous",
+      "Value": "System.Web.Mvc.AllowAnonymousAttribute.AllowAnonymousAttribute()",
+      "KeyType": "Name",
+      "ContainingType": "AllowAnonymousAttribute",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.Web.Mvc namespace with Microsoft.AspNetCore.Authorization.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authorization",
+              "Description": "Add Microsoft.AspNetCore.Authorization namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authorization;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Attribute",
+      "Name": "Authorize",
+      "Value": "System.Web.Mvc.AuthorizeAttribute.AuthorizeAttribute()",
+      "KeyType": "Name",
+      "ContainingType": "AuthorizeAttribute",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.Web.Mvc namespace with Microsoft.AspNetCore.Authorization.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authorization",
+              "Description": "Add Microsoft.AspNetCore.Authorization namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authorization;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "SelectList",
+      "Value": "System.Web.Mvc.SelectList",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.Rendering.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc.Rendering",
+              "Description": "Add Microsoft.AspNetCore.Mvc.Rendering namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc.Rendering;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "FormCollection",
+      "Value": "System.Web.Mvc.FormCollection",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.Web.Mvc namespace with Microsoft.AspNetCore.Http.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "ActionFilterAttribute",
+      "Value": "System.Web.Mvc.ActionFilterAttribute",
+      "KeyType": "BaseClass",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.Filters.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc.Filters",
+              "Description": "Add Microsoft.AspNetCore.Mvc.Filters namespace.",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc.Filters;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.Mvc.Controller.HttpNotFound()",
+      "Value": "System.Web.Mvc.Controller.HttpNotFound()",
+      "KeyType": "Name",
+      "ContainingType": "Controller",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace HttpNotFound with NotFound and replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "HttpNotFound",
+                "newMethod": "NotFound"
+              },
+              "Description": "Replace HttpNotFound with NotFound",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "HttpNotFound"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.Mvc.Controller.HttpNotFound(string)",
+      "Value": "System.Web.Mvc.Controller.HttpNotFound(string)",
+      "KeyType": "Name",
+      "ContainingType": "Controller",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace HttpNotFound with NotFound and replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "HttpNotFound",
+                "newMethod": "NotFound"
+              },
+              "Description": "Replace HttpNotFound with NotFound",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "HttpNotFound"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.Mvc.IDependencyResolver.GetService(*)",
+      "Value": "System.Web.Mvc.IDependencyResolver.GetService(*)",
+      "KeyType": "Name",
+      "ContainingType": "IDependencyResolver",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace DependencyResolver.Current.GetService with HttpContext.RequestServices.GetService and replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodWithObject",
+              "Type": "Method",
+              "Value": {
+                "newMethod": "HttpContext.RequestServices.GetService"
+              },
+              "Description": "Replace object invoking GetService",
+              "ActionValidation": {
+                "Contains": "HttpContext.RequestServices.GetService",
+                "NotContains": "DependencyResolver.Current.GetService"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.Mvc.IDependencyResolver.GetService<*>()",
+      "Value": "System.Web.Mvc.IDependencyResolver.GetService<*>()",
+      "KeyType": "Name",
+      "ContainingType": "DependencyResolverExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace DependencyResolver.Current.GetService with HttpContext.RequestServices.GetService and replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodWithObjectAddType",
+              "Type": "Method",
+              "Value": {
+                "newMethod": "HttpContext.RequestServices.GetService"
+              },
+              "Description": "Replace object invoking GetService",
+              "ActionValidation": {
+                "Contains": "HttpContext.RequestServices.GetService",
+                "NotContains": "DependencyResolver.Current.GetService"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.Mvc.DependencyResolver.SetResolver(System.Web.Mvc.IDependencyResolver)",
+      "Value": "System.Web.Mvc.DependencyResolver.SetResolver(System.Web.Mvc.IDependencyResolver)",
+      "KeyType": "Name",
+      "ContainingType": "DependencyResolver",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a comment: Use the startup class to register dependency containers.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "This method is not supported. Use the startup class to register dependency containers",
+              "Description": "Use the startup class to register dependency containers",
+              "ActionValidation": {
+                "Contains": "This method is not supported. Use the startup class to register dependency containers",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.Mvc.Controller.TryUpdateModel(*)",
+      "Value": "System.Web.Mvc.Controller.TryUpdateModel(*)",
+      "KeyType": "Name",
+      "ContainingType": "Controller",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace TryUpdateModel with TryUpdateModelAsync and replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "TryUpdateModel",
+                "newMethod": "TryUpdateModelAsync"
+              },
+              "Description": "Replace TryUpdateModel with TryUpdateModelAsync",
+              "ActionValidation": {
+                "Contains": "TryUpdateModelAsync",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "This updated method might require the parameters to be re-organized",
+              "Description": "Add a comment to inform the user to reorganize the parameters",
+              "ActionValidation": {
+                "Contains": "This updated method might require the parameters to be re-organized",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "System.Web.Mvc.Controller.TryUpdateModel<*>(*)",
+      "Value": "System.Web.Mvc.Controller.TryUpdateModel<*>(*)",
+      "KeyType": "Name",
+      "ContainingType": "Controller",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Replace TryUpdateModel with TryUpdateModelAsync and replace System.Web.Mvc namespace with Microsoft.AspNetCore.Mvc.",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodOnly",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "TryUpdateModel",
+                "newMethod": "TryUpdateModelAsync"
+              },
+              "Description": "Replace TryUpdateModel with TryUpdateModelAsync",
+              "ActionValidation": {
+                "Contains": "TryUpdateModelAsync",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Mvc",
+              "Description": "Add Microsoft.AspNetCore.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Mvc;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "System.Web.Mvc",
+              "Description": "Remove System.Web.Mvc namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using System.Web.Mvc;"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "This updated method might require the parameters to be re-organized",
+              "Description": "Add a comment to inform the user to reorganize the parameters",
+              "ActionValidation": {
+                "Contains": "This updated method might require the parameters to be re-organized",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/TempRules/wcf.client.json
+++ b/tst/CTA.Rules.Test/TempRules/wcf.client.json
@@ -1,0 +1,73 @@
+{
+  "Name": "WCF.Client",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Project",
+      "Type": "Project"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Project",
+      "Name": "Project",
+      "Value": "WCFClient",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net6.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "System.ServiceModel.Primitives",
+              "Description": "Add package System.ServiceModel.Primitives."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "System.ServiceModel.Http",
+              "Description": "Add package System.ServiceModel.Http."
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "System.ServiceModel.NetTcp",
+              "Description": "Add package System.ServiceModel.NetTcp."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tst/CTA.Rules.Test/WCFTests.cs
+++ b/tst/CTA.Rules.Test/WCFTests.cs
@@ -18,6 +18,7 @@ namespace CTA.Rules.Test
             downloadLocation = SetupTests.DownloadLocation;
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBasicHttpBindingAndTransportSecurity(string version)
@@ -55,6 +56,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBasicHttpTransportMessageCredUserName(string version)
@@ -92,6 +94,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBasicHttpTransportMessageCredCertificate(string version)
@@ -129,6 +132,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestWSHttpBindingWithWindowsAuth(string version)
@@ -166,6 +170,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBasicHttpMessageSecurity(string version)
@@ -188,6 +193,7 @@ namespace CTA.Rules.Test
             FileAssert.DoesNotExist(Path.Combine(projectDir, "Program.cs"));
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestNetTCPBindingDefaultSecurity(string version)
@@ -225,6 +231,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestNetPipeBindingDefault(string version)
@@ -247,6 +254,7 @@ namespace CTA.Rules.Test
             FileAssert.DoesNotExist(Path.Combine(projectDir, "Program.cs"));
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBasicHttpAndNetTCPSupported(string version)
@@ -284,6 +292,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestWsHttpAndNetPipe(string version)
@@ -321,6 +330,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestCodeBasedBasicHttpDefaultSecurity(string version)
@@ -353,6 +363,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestCodeBasicHttpTransportSecurity(string version)
@@ -385,6 +396,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestCodeBasicHttpTransportMessageCredUserName(string version)
@@ -417,6 +429,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestCodeBasicHttpNetTCPSupported(string version)
@@ -449,6 +462,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"using CoreWCF", service);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestWCFClient(string version)
@@ -466,6 +480,7 @@ namespace CTA.Rules.Test
             StringAssert.Contains(@"System.ServiceModel.NetTcp", csProjContent);
         }
 
+        [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestWCFServiceLibrary(string version)


### PR DESCRIPTION
## Related issue

Closes: #420


## Description
* Update unit tests with .NET 6 test cases
* Combine CreateFolderHierarchy action into a single function used by netcoreapp3.1, net5.0, and net6.0 target frameworks
* Add temp rules required for unit tests 

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
