### PR TITLE
Comment out encrypted connection strings in web.config

### DIFF
--- a/src/CTA.Rules.Actions/ActionHelpers/ConfigMigrate.cs
+++ b/src/CTA.Rules.Actions/ActionHelpers/ConfigMigrate.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using CTA.Rules.Config;
 using CTA.Rules.Models;
 using Newtonsoft.Json;
@@ -17,6 +18,11 @@ namespace CTA.Rules.Actions
         private readonly ProjectType _projectType;
         private bool _hasData;
 
+        /// <summary>
+        /// If connection string is encrypted,  "configProtectionProvider" is present.
+        /// </summary>
+        private const string providerForEncryptedConnString = "configProtectionProvider";
+
         public ConfigMigrate(string projectDir, ProjectType projectType)
         {
             _projectDir = Directory.GetParent(projectDir).FullName;
@@ -27,6 +33,7 @@ namespace CTA.Rules.Actions
         {
             return MigrateWebConfig();
         }
+
         /// <summary>
         /// Migrates the web.config file, if it exists
         /// </summary>
@@ -67,19 +74,47 @@ namespace CTA.Rules.Actions
 
         private Configuration LoadWebConfig(string projectDir)
         {
-            string webConfigFile = Path.Combine(projectDir, Constants.WebConfig);
+            string webConfigFilePath = Path.Combine(projectDir, Constants.WebConfig);
 
-            if (File.Exists(webConfigFile))
+            if (File.Exists(webConfigFilePath))
             {
                 try
                 {
-                    var fileMap = new ExeConfigurationFileMap() { ExeConfigFilename = webConfigFile };
+
+                    XElement webConfigXml = XElement.Load(webConfigFilePath);
+                    System.Xml.XmlDocument xmlDocument = new System.Xml.XmlDocument();
+                    xmlDocument.Load(webConfigFilePath);
+
+                    // Comment out connection strings if type has a configProtectionProvider
+                    // This can comment out connection strings that do not have "EncryptedData"
+                    IEnumerable<XElement> encryptedConnectionStringElement =
+                        from element in webConfigXml.Elements("connectionStrings")
+                        where (string)element.Attribute("configProtectionProvider") != null
+                        select element;
+
+                    if (encryptedConnectionStringElement.HasAny())
+                    {
+                        System.Xml.XmlNode elementToComment = xmlDocument.SelectSingleNode("/configuration/connectionStrings");
+                        string commentContents = elementToComment.OuterXml;
+
+                        // Its contents are the XML content of target node
+                        System.Xml.XmlComment commentNode = xmlDocument.CreateComment(commentContents);
+
+                        // Get a reference to the parent of the target node
+                        System.Xml.XmlNode parentNode = elementToComment.ParentNode;
+
+                        // Replace the target node with the comment
+                        parentNode.ReplaceChild(commentNode, elementToComment);
+                        xmlDocument.Save(webConfigFilePath);
+                    }
+
+                    var fileMap = new ExeConfigurationFileMap() { ExeConfigFilename = webConfigFilePath };
                     var configuration = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None);
                     return configuration;
                 }
                 catch (Exception ex)
                 {
-                    LogHelper.LogError(ex, string.Format("Error processing web.config file {0}", webConfigFile));
+                    LogHelper.LogError(ex, string.Format("Error processing web.config file {0}", webConfigFilePath));
                 }
             }
             return null;
@@ -181,7 +216,7 @@ namespace CTA.Rules.Actions
 
         /// <summary>
         /// Writes the appSettings.json file to the project dir
-        /// </summary>        
+        /// </summary>
         /// <param name="content">The content of the file</param>
         /// <param name="projectDir">The project directory where this file will be created</param>
         private void AddAppSettingsJsonFile(JObject content, string projectDir)

--- a/tst/CTA.Rules.Test/Actions/ActionHelpers/ConfigMigrateTests.cs
+++ b/tst/CTA.Rules.Test/Actions/ActionHelpers/ConfigMigrateTests.cs
@@ -101,7 +101,7 @@ namespace CTA.Rules.Test.Actions.ActionHelpers
     <connectionStrings>
         <add name=""MusicStoreEntities"" connectionString=""{0}"" providerName=""System.Data.SqlClient""/>
         <add name=""MvcMusicStoreAuth"" connectionString=""{1}"" providerName=""System.Data.SqlClient"" />
-    </connectionStrings> 
+    </connectionStrings>
 </configuration>
 ", connectionStringWithBackSlash, connectionString2);
 
@@ -124,6 +124,79 @@ namespace CTA.Rules.Test.Actions.ActionHelpers
 
             Assert.True(appSettingsContent.Contains(connectionStringWithBackSlash.Replace(@"\", @"\\")));
             Assert.True(appSettingsContent.Contains(connectionString2));
+        }
+
+        [Test]
+        public void AddConfigWithoutAppSettingsAndWithEncryptedConnectionString()
+        {
+            // Get private method to invoke
+            var projectType = ProjectType.ClassLibrary;
+            ConfigMigrate configMigrateInstance = new ConfigMigrate(Directory.GetCurrentDirectory(), projectType);
+            Type configMigrateType = configMigrateInstance.GetType();
+
+            var loadWebConfigMethod = TestUtils.GetPrivateMethod(configMigrateType, "LoadWebConfig");
+            var processWebConfigMethod = TestUtils.GetPrivateMethod(configMigrateType, "ProcessWebConfig");
+            var addAppSettingsJsonFileMethod = TestUtils.GetPrivateMethod(configMigrateType, "AddAppSettingsJsonFile");
+
+            var encryptedConnectionString = (@" <EncryptedData Type=""http://www.w3.org/2001/04/xmlenc#Element""
+      xmlns=""http://www.w3.org/2001/04/xmlenc#"">
+      <EncryptionMethod Algorithm=""http://www.w3.org/2001/04/xmlenc#aes256-cbc"" />
+      <KeyInfo xmlns=""http://www.w3.org/2000/09/xmldsig#"">
+        <EncryptedKey xmlns=""http://www.w3.org/2001/04/xmlenc#"">
+          <EncryptionMethod Algorithm=""http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"" />
+          <KeyInfo xmlns=""http://www.w3.org/2000/09/xmldsig#"">
+            <KeyName>Rsa Key</KeyName>
+          </KeyInfo>
+          <CipherData>
+            <CipherValue>nkxQIoF9mSLILi28QYHJJgWdKARI7wi6Eobci45cobGuGqT6O7CDSTnDm2MEP1AGOkp/WYsWPZu+m1AVCwM+L9XNClKn0JQD/0EjW8Xt5J6EbNadQ0+jaWoeLdG5zuDDEzrKd3L13nAOuZngXCM0iKh1Lp9jVDojbcaXVt88cK5SD6V0z/8ug+7g+sZqLVJd6zyRzBenbNB5w+XVUCcLkAIfgBlvLvx26CrZ2sq36iRmmO1xM1VkXvKfMDb0Mu4UTwNcxB17fipgj4eu5AUfQj+nKbagSwFVmOOw92rVYr6jgveElgoSiqzL/sN01eT+xCKDWXqcS7T5ks5QQIIh/A==</CipherValue>
+          </CipherData>
+        </EncryptedKey>
+      </KeyInfo>
+      <CipherData>
+        <CipherValue>TD/NPQ/BWh1C95odOotarRZDT3pENWUEKbGULkBFE/iL39rq7L5HvxgezKqz6YKLhUm2LyU05VE03dGPP5yJQVW6bAJjHIC47hVzlzIRehx7ihk4yDqgrROpwmGl9zw1n/V+QDwrqnkYOPZE9ubZsgPPSaWf7/FwtrbpRbWLXLzmBT4LRxOBeZLmSM40XMYkZgQiUAWNw6tu6XiFg7y/kbBXGa2jzoAXPaxcMqjhyQfVGyDhirOh5vmSJJV+kkiZ43KQIv/eoKv6pylHnocP0rW05y5Jl1YfgsiXJVqhDFYsd8wHqUe5iuOwqE4n5KiDwf37Z6HRwnnCKsw2O6bzud4lEsKjFte/FpL/esBxrQvCAmDIgix8UEadDqlCG3cG</CipherValue>
+      </CipherData>
+    </EncryptedData>");
+            var connectionString2 = @"Data Source=Test;Initial Catalog=ContosoUniversity1;Integrated Security=SSPI;";
+            var defaultConnectionString = @"data source=.\\SQLEXPRESS;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|aspnetdb.mdf;User Instance=true";
+            var connectionStrings = string.Format(@"<connectionStrings configProtectionProvider=""RsaProtectedConfigurationProvider"">
+                                                        {0}
+                                                        <add name=""MvcMusicStoreAuth"" connectionString=""{1}"" providerName=""System.Data.SqlClient"" />
+                                                        </connectionStrings>",
+                                                        encryptedConnectionString, connectionString2);
+
+            var webConfig = string.Format(@"
+<configuration>
+                <runtime>
+                  <assemblyBinding xmlns=""urn:schemas-microsoft-com:asm.v1"">
+                                                  <dependentAssembly>
+                                            <assemblyIdentity name=""System.Web.Mvc"" publicKeyToken=""31bf3856ad364e35""/>
+                                        <bindingRedirect oldVersion=""3.0.0.0-3.0.0.1"" newVersion=""3.0.0.1""/>
+                                       </dependentAssembly>
+                                          </assemblyBinding>
+                                      </runtime>
+                                          {0}
+                                 </configuration>",
+                                 connectionStrings);
+
+            File.WriteAllText("web.config", webConfig);
+
+            var templateContent = @"{}";
+            var outputDir = "";
+
+            var configuration = (Configuration)loadWebConfigMethod.Invoke(configMigrateInstance, new object[] { outputDir });
+
+            // Invoke method and read contents of method output
+            var content = (JObject)processWebConfigMethod.Invoke(configMigrateInstance, new object[] { configuration, templateContent });
+
+            var methodParams = new object[] { content, outputDir };
+            addAppSettingsJsonFileMethod.Invoke(configMigrateInstance, methodParams);
+
+            var appSettingsContent = File.ReadAllText(Path.Combine(outputDir, "appsettings.json"));
+
+            File.Delete(Path.Combine(outputDir, "appsettings.json"));
+            File.Delete(Path.Combine(outputDir, "web.config"));
+
+            Assert.True(appSettingsContent.Contains(defaultConnectionString));
         }
 
         [Test]


### PR DESCRIPTION
Encrypted connection strings need to be ported to appsettings.json by end user.

## Description
CTA changes to comment out encrypted connection strings in web.config, so that loading web.config does not result in error.
Encrypted connection strings need to be ported to appsettings.json by end user.

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
