### PR TITLE
Fix identifier name bug for qualified name

### DIFF
--- a/src/CTA.Rules.Update/ActionsRewriter.cs
+++ b/src/CTA.Rules.Update/ActionsRewriter.cs
@@ -30,7 +30,8 @@ namespace CTA.Rules.Update.Rewriters
             typeof(TypeArgumentListSyntax),
             typeof(TypeParameterListSyntax),
             typeof(ParameterSyntax),
-            typeof(ObjectCreationExpressionSyntax)};
+            typeof(ObjectCreationExpressionSyntax),
+            typeof(QualifiedNameSyntax)};
 
         public ActionsRewriter(SemanticModel semanticModel, SemanticModel preportSemanticModel, SyntaxGenerator syntaxGenerator, string filePath, List<GenericAction> allActions)
         {

--- a/tst/CTA.Rules.Test/Actions/IdentifierNameActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/IdentifierNameActionsTests.cs
@@ -1,0 +1,63 @@
+﻿using CTA.Rules.Actions;
+using CTA.Rules.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CTA.Rules.Test.Actions
+{
+    public class IdentifierNameActionsTests
+    {
+        private SyntaxGenerator _syntaxGenerator;
+        private IdentifierNameActions _identifierNameActions;
+        private IdentifierNameSyntax _node;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var workspace = new AdhocWorkspace();
+            var language = LanguageNames.CSharp;
+            _syntaxGenerator = SyntaxGenerator.GetGenerator(workspace, language);
+            _identifierNameActions = new IdentifierNameActions();
+            _node = (IdentifierNameSyntax)_syntaxGenerator.IdentifierName("MusicStoreEntities");
+        }
+
+        [Test]
+        public void ReplaceIdentifierInsideClassActionTest()
+        {
+            string newIdentifier = "SuperAwesomeClass.SomethingElse";
+            string originalIdentifier = "SuperAwesomeClass.MusicStoreEntities";
+            string namespaceName = "MvcMusicStore.Controllers";
+            string className = "ShoppingCartController";
+            SyntaxNode customNode = _syntaxGenerator.NamespaceDeclaration(namespaceName,
+                _syntaxGenerator.ClassDeclaration(className, null, Accessibility.NotApplicable, DeclarationModifiers.None, _syntaxGenerator.IdentifierName("Controller"), null, 
+                new List<SyntaxNode>() {
+                        _syntaxGenerator.FieldDeclaration("storeDB", _syntaxGenerator.IdentifierName(originalIdentifier), Accessibility.Public, DeclarationModifiers.None, 
+                            _syntaxGenerator.ObjectCreationExpression(SyntaxFactory.ParseTypeName(originalIdentifier)))
+                })).NormalizeWhitespace();
+
+            var replaceIdentifierFunc =
+                _identifierNameActions.GetReplaceIdentifierInsideClassAction(newIdentifier, namespaceName + "." + className);
+            FieldDeclarationSyntax variableDeclaration = (FieldDeclarationSyntax)customNode.ChildNodes().FirstOrDefault(c => c.IsKind(SyntaxKind.ClassDeclaration)).ChildNodes().FirstOrDefault(f => f.IsKind(SyntaxKind.FieldDeclaration));
+
+            var newNode = replaceIdentifierFunc(_syntaxGenerator, (IdentifierNameSyntax)variableDeclaration.Declaration.Type);
+
+            Assert.AreEqual(newIdentifier, newNode.ToFullString().Trim());
+        }
+
+        [Test]
+        public void ReplaceIdentifierActionTest()
+        {
+            string newIdentifier = "SomethingElse";
+            var removeAttributeFunc =
+                _identifierNameActions.GetReplaceIdentifierAction(newIdentifier);
+            var newNode = removeAttributeFunc(_syntaxGenerator, _node);
+
+            Assert.AreEqual(newIdentifier, newNode.ToFullString());
+        }
+    }
+}


### PR DESCRIPTION
## Related issue

Closes: #430 


## Description
[GA Blocker] CTA needs to handle namespace prefixed to class names for its ReplaceIdentifierInsideClass action

The actual issue lies in the Key and Full key not matching properly to activate the action.

After careful review the problem was located in the ActionRewriter.cs class and how it would skip executing the action after it had been loaded since it was not part of accepted IdentifierName types.

## Supplemental testing
All unit test pass.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
