### PR TITLE
Added basic asp:TextBox control support

### DIFF
--- a/src/CTA.WebForms2Blazor/ControlConverters/ControlConverter.cs
+++ b/src/CTA.WebForms2Blazor/ControlConverters/ControlConverter.cs
@@ -15,12 +15,12 @@ namespace CTA.WebForms2Blazor.ControlConverters
             get { return new Dictionary<string, string>(); }
         }
 
-        protected virtual IEnumerable<ViewLayerControlAttribute> NewAttributes
-        {
-            get { return new List<ViewLayerControlAttribute>(); }
-        }
+        protected virtual IEnumerable<ViewLayerControlAttribute> NewAttributes { get; set; }
+            = new List<ViewLayerControlAttribute>();
+
         protected abstract string BlazorName { get; }
         protected virtual string NodeTemplate { get { return @"<{0} {1}>{2}</{0}>"; } }
+        protected virtual string SingleTagNodeTemplate { get { return @"<{0} {1}>"; } }
         
         //Passing this method through every .CreateNode ensures that all nodes have original capitalization
         public static void PreserveCapitalization(HtmlDocument htmlDocument)

--- a/src/CTA.WebForms2Blazor/Helpers/ControlHelpers/SupportedControls.cs
+++ b/src/CTA.WebForms2Blazor/Helpers/ControlHelpers/SupportedControls.cs
@@ -21,6 +21,7 @@ namespace CTA.WebForms2Blazor.Helpers.ControlHelpers
             ["asp:listview"] = new ListViewControlConverter(),
             ["asp:gridview"] = new GridViewControlConverter(),
             ["asp:content"] = new RemoveNodeKeepContentsConverter(),
+            ["asp:textbox"] = new TextBoxControlConverter(),
             ["html"] = new RemoveNodeKeepContentsConverter(),
             ["body"] = new RemoveNodeKeepContentsConverter(),
             ["head"] = new RemoveNodeAndContentsConverter(),

--- a/tst/CTA.WebForms2Blazor.Tests/ControlConverters/TextBoxControlConverterTests.cs
+++ b/tst/CTA.WebForms2Blazor.Tests/ControlConverters/TextBoxControlConverterTests.cs
@@ -1,0 +1,82 @@
+﻿using CTA.WebForms2Blazor.ControlConverters;
+using HtmlAgilityPack;
+using NUnit.Framework;
+
+namespace CTA.WebForms2Blazor.Tests.ControlConverters
+{
+    public class TextBoxControlConverterTests
+    {
+        private TextBoxControlConverter _testConverter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testConverter = new TextBoxControlConverter();
+        }
+
+        [Test]
+        public void Convert2Blazor_Returns_Standard_Input_For_SingleLine_Text_Mode()
+        {
+            var htmlString = @"<asp:TextBox ID=""TestId"" Text=""Example Text"">";
+            var expectedString = @"<input id=""TestId"" value=""Example Text"">";
+
+            var htmlNode = HtmlNode.CreateNode(htmlString, ControlConverter.PreserveCapitalization);
+            var convertedNode = _testConverter.Convert2Blazor(htmlNode);
+            var actualString = convertedNode.WriteTo();
+
+            Assert.AreEqual(expectedString, actualString);
+        }
+
+        [Test]
+        public void Convert2Blazor_Returns_TextArea_Input_For_MultiLine_Text_Mode()
+        {
+            var htmlString = @"<asp:TextBox ID=""TestId"" TextMode=""MultiLine"" Text=""Example Text"">";
+            var expectedString = @"<textarea id=""TestId"">Example Text</textarea>";
+
+            var htmlNode = HtmlNode.CreateNode(htmlString, ControlConverter.PreserveCapitalization);
+            var convertedNode = _testConverter.Convert2Blazor(htmlNode);
+            var actualString = convertedNode.WriteTo();
+
+            Assert.AreEqual(expectedString, actualString);
+        }
+
+        [Test]
+        public void Convert2Blazor_Sets_Password_Type_For_Password_Text_Mode()
+        {
+            var htmlString = @"<asp:TextBox ID=""TestId"" TextMode=""Password"">";
+            var expectedString = @"<input id=""TestId"" type=""password"">";
+
+            var htmlNode = HtmlNode.CreateNode(htmlString, ControlConverter.PreserveCapitalization);
+            var convertedNode = _testConverter.Convert2Blazor(htmlNode);
+            var actualString = convertedNode.WriteTo();
+
+            Assert.AreEqual(expectedString, actualString);
+        }
+
+        [Test]
+        public void Convert2Blazor_Sets_ReadOnly_Attribute_Properly()
+        {
+            var htmlString = @"<asp:TextBox ID=""TestId"" Text=""Example Text"" ReadOnly=""true"">";
+            var expectedString = @"<input id=""TestId"" value=""Example Text"" readonly="""">";
+
+            var htmlNode = HtmlNode.CreateNode(htmlString, ControlConverter.PreserveCapitalization);
+            var convertedNode = _testConverter.Convert2Blazor(htmlNode);
+            var actualString = convertedNode.WriteTo();
+
+            Assert.AreEqual(expectedString, actualString);
+        }
+
+        [Test]
+        public void Convert2Blazor_Sets_Disabled_Attribute_Properly()
+        {
+            var htmlString = @"<asp:TextBox ID=""TestId"" Text=""Example Text"" Enabled=""false"">";
+            var expectedString = @"<input id=""TestId"" value=""Example Text"" disabled="""">";
+
+            var htmlNode = HtmlNode.CreateNode(htmlString, ControlConverter.PreserveCapitalization);
+            var convertedNode = _testConverter.Convert2Blazor(htmlNode);
+            var actualString = convertedNode.WriteTo();
+
+            Assert.AreEqual(expectedString, actualString);
+        }
+    }
+}


### PR DESCRIPTION
## Description
* Control converters will now pick up asp:TextBox components
* Added support for main attributes/events used by asp:TextBox
* Added node template for single tag nodes
* Note that code-behind references to asp:TextBox components and other
advanced features are still not being handled, as is the case with the
other control converters

## Supplemental testing
* Added unit tests for new control converter

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
