### PR TITLE
Fixed http module lc events not being recognized

### DIFF
--- a/src/CTA.WebForms2Blazor/ClassConverters/HttpModuleClassConverter.cs
+++ b/src/CTA.WebForms2Blazor/ClassConverters/HttpModuleClassConverter.cs
@@ -265,10 +265,27 @@ namespace CTA.WebForms2Blazor.ClassConverters
 
                     if (objCreationExpr != null && objCreationExpr.Type.ToString().Equals(typeof(EventHandler).Name))
                     {
-                        var arguments = objCreationExpr.ArgumentList.Arguments;
-                        var memberAccessExpr = arguments.FirstOrDefault().Expression as MemberAccessExpressionSyntax;
-                        var methodName = memberAccessExpr.Name.ToString();
-                        results.Add((methodName, (WebFormsAppLifecycleEvent)lcEvent));
+                        try
+                        {
+                            var arguments = objCreationExpr.ArgumentList.Arguments;
+                            var methodNameExpr = arguments.FirstOrDefault()?.Expression;
+
+                            string methodName = null;
+                            if (methodNameExpr is MemberAccessExpressionSyntax)
+                            {
+                                methodName = (methodNameExpr as MemberAccessExpressionSyntax).Name.ToString();
+                            }
+                            else
+                            {
+                                methodName = (methodNameExpr as IdentifierNameSyntax).Identifier.ToString();
+                            }
+                            results.Add((methodName, (WebFormsAppLifecycleEvent)lcEvent));
+                        }
+                        catch (Exception e)
+                        {
+                            LogHelper.LogError(e, $"Failed to retrieve event method name from expression '{objCreationExpr}'" +
+                                $"while processing Init method of {OriginalClassName} class");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
* Issue causing this bug was the assumption that expression inside event handler would be a member access expression, this is true for something like "this.Application_BeginRequest" but not "Application_BeginRequest" which registers as an identifier name syntax
* Added checks to allow for identifier syntax as well as member access when retrieving method names
* Added some null checks and error handling on failure to retrieve method name as well

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
