### PR TITLE
Fixed WebForms UI Regexes

### DIFF
--- a/src/CTA.WebForms/Helpers/ControlHelpers/EmbeddedCodeReplacers.cs
+++ b/src/CTA.WebForms/Helpers/ControlHelpers/EmbeddedCodeReplacers.cs
@@ -16,38 +16,38 @@ namespace CTA.WebForms.Helpers.ControlHelpers
         /// Regular expression to identify data binding syntax, matches start and end
         /// tags (<%# or <%#: and %>) with content that does not contain the end tag
         /// </summary>
-        public static Regex DataBindRegex = new Regex(@"<%#:?\s*(?<expr>[^:](?:(?!%>).)*)\s*%>");
+        public static Regex DataBindRegex = new Regex(@"<%#:?\s*(?<expr>[^:](?:(?!%>).)*)\s*%>", RegexOptions.Singleline);
         /// <summary>
         /// Regular expression to identify raw expression syntax, matches start and end
         /// tags (<%= and %>) with content that does not contain the end tag
         /// </summary>
-        public static Regex RawExprRegex = new Regex(@"<%=\s*(?<expr>(?:(?!%>).)*)\s*%>");
+        public static Regex RawExprRegex = new Regex(@"<%=\s*(?<expr>(?:(?!%>).)*)\s*%>", RegexOptions.Singleline);
         /// <summary>
         /// Regular expression to identify html encoded expression syntax, matches start
         /// and end tags (<%: and %>) with content that does not contain the end tag
         /// </summary>
-        public static Regex HTMLEncodedExprRegex = new Regex(@"<%:\s*(?<expr>(?:(?!%>).)*)\s*%>");
+        public static Regex HTMLEncodedExprRegex = new Regex(@"<%:\s*(?<expr>(?:(?!%>).)*)\s*%>", RegexOptions.Singleline);
         /// <summary>
         /// Regular expression to identify directive syntax, matches start and end
         /// tags (<%@ and %>) with content that does not contain the end tag
         /// </summary>
-        public static Regex DirectiveRegex = new Regex(@"<%@\s*(?<expr>(?:(?!%>).)*)\s*%>");
+        public static Regex DirectiveRegex = new Regex(@"<%@\s*(?<expr>(?:(?!%>).)*)\s*%>", RegexOptions.Singleline);
         /// <summary>
         /// Regular expression to identify asp expression syntax, matches start and end
         /// tags (<%$ and %>) with content that does not contain the end tag
         /// </summary>
-        public static Regex AspExpRegex = new Regex(@"<%\$\s*(?<exprType>[^*]+):\s*(?<expr>(?:(?!%>).)+)\s*%>");
+        public static Regex AspExpRegex = new Regex(@"<%\$\s*(?<exprType>[^*]+):\s*(?<expr>(?:(?!%>).)+)\s*%>", RegexOptions.Singleline);
         /// <summary>
         /// Regular expression to identify asp comment syntax, matches start and end tags
         /// (<%-- and --%>) with content that does not contain the end tag
         /// </summary>
-        public static Regex AspCommentRegex = new Regex(@"<%--\s*(?<expr>(?:(?!--%>).)*)\s*--%>");
+        public static Regex AspCommentRegex = new Regex(@"<%--\s*(?<expr>(?:(?!--%>).)*)\s*--%>", RegexOptions.Singleline);
         /// <summary>
         /// Regular expression to identify code block syntax, matches start and end
         /// tags (<%# and %>) with content that does not contain the end tag and has
         /// extra conditions to ensure other embedding syntaxes aren't matched accidentally
         /// </summary>
-        public static Regex EmbeddedCodeBlockRegex = new Regex(@"<%(?!(?:--)|[#=:@\$]).\s*(?<expr>(?:(?!%>).)*)\s*%>");
+        public static Regex EmbeddedCodeBlockRegex = new Regex(@"<%(?!(?:--)|[#=:@\$]).\s*(?<expr>(?:(?!%>).)*)\s*%>", RegexOptions.Singleline);
 
         /// <summary>
         /// Regular expression to identify directive name within directive syntax content,

--- a/tst/CTA.WebForms.Tests/Helpers/ControlHelpers/EmbededCodeReplacerTests.cs
+++ b/tst/CTA.WebForms.Tests/Helpers/ControlHelpers/EmbededCodeReplacerTests.cs
@@ -7,6 +7,7 @@ namespace CTA.WebForms.Tests.Helpers.ControlHelpers
     {
         private const string NormalExpressionContent = "normal expression content";
         private const string MutualTagCharExpressionContent = "mutual %_tag_% chars";
+        private const string MultiLineExpressionContent = "<div>\n<p>\nText\n<\\p>\n<\\div>";
 
         private const string AppSettingsSectionName = "appsettings";
         private const string AppSettingsAspExpressionType = "AppSettings";
@@ -50,6 +51,14 @@ namespace CTA.WebForms.Tests.Helpers.ControlHelpers
         }
 
         [Test]
+        public void DataBindRegex_Matches_Expression_With_Multi_Line_Content()
+        {
+            var inputText = $"{WebFormsOneWayDataBindStartTag} {MultiLineExpressionContent} {WebFormsNormalEndTag}";
+
+            Assert.True(EmbeddedCodeReplacers.DataBindRegex.IsMatch(inputText));
+        }
+
+        [Test]
         public void DataBindRegex_Does_Not_Match_Expressions_With_Malformed_Tag_Braces()
         {
             var inputText = $"{WebFormsOneWayDataBindStartTag} {NormalExpressionContent} {WebFormsMalformedEndTag}";
@@ -69,6 +78,14 @@ namespace CTA.WebForms.Tests.Helpers.ControlHelpers
         public void RawExprRegex_Matches_Expressions_With_Characters_Mutual_To_Tag_Braces()
         {
             var inputText = $"{WebFormsRawExpressionStartTag} {MutualTagCharExpressionContent} {WebFormsNormalEndTag}";
+
+            Assert.True(EmbeddedCodeReplacers.RawExprRegex.IsMatch(inputText));
+        }
+
+        [Test]
+        public void RawExprRegex_Matches_Expression_With_Multi_Line_Content()
+        {
+            var inputText = $"{WebFormsRawExpressionStartTag} {MultiLineExpressionContent} {WebFormsNormalEndTag}";
 
             Assert.True(EmbeddedCodeReplacers.RawExprRegex.IsMatch(inputText));
         }
@@ -98,6 +115,14 @@ namespace CTA.WebForms.Tests.Helpers.ControlHelpers
         }
 
         [Test]
+        public void HTMLEncodedExprRegex_Matches_Expression_With_Multi_Line_Content()
+        {
+            var inputText = $"{WebFormsHTMLEncodedExpressionStartTag} {MultiLineExpressionContent} {WebFormsNormalEndTag}";
+
+            Assert.True(EmbeddedCodeReplacers.HTMLEncodedExprRegex.IsMatch(inputText));
+        }
+
+        [Test]
         public void HTMLEncodedExprRegex_Does_Not_Match_Expressions_With_Malformed_Tag_Braces()
         {
             var inputText = $"{WebFormsHTMLEncodedExpressionStartTag} {NormalExpressionContent} {WebFormsMalformedEndTag}";
@@ -122,6 +147,14 @@ namespace CTA.WebForms.Tests.Helpers.ControlHelpers
         }
 
         [Test]
+        public void DirectiveRegex_Matches_Expression_With_Multi_Line_Content()
+        {
+            var inputText = $"{WebFormsDirectiveStartTag} {MultiLineExpressionContent} {WebFormsNormalEndTag}";
+
+            Assert.True(EmbeddedCodeReplacers.DirectiveRegex.IsMatch(inputText));
+        }
+
+        [Test]
         public void DirectiveRegex_Does_Not_Match_Expressions_With_Malformed_Tag_Braces()
         {
             var inputText = $"{WebFormsDirectiveStartTag} {NormalExpressionContent} {WebFormsMalformedEndTag}";
@@ -133,6 +166,14 @@ namespace CTA.WebForms.Tests.Helpers.ControlHelpers
         public void AspExpRegex_Matches_Normal_Correct_Expressions()
         {
             var inputText = $"{WebFormsAspExpressionStartTag} {AppSettingsAspExpressionType}: {AppSettingsAspExpressionContent} {WebFormsNormalEndTag}";
+
+            Assert.True(EmbeddedCodeReplacers.AspExpRegex.IsMatch(inputText));
+        }
+
+        [Test]
+        public void AspExpRegex_Matches_Expression_With_Multi_Line_Content()
+        {
+            var inputText = $"{WebFormsAspExpressionStartTag} {AppSettingsAspExpressionType}:\n {AppSettingsAspExpressionContent} {WebFormsNormalEndTag}";
 
             Assert.True(EmbeddedCodeReplacers.AspExpRegex.IsMatch(inputText));
         }
@@ -162,6 +203,14 @@ namespace CTA.WebForms.Tests.Helpers.ControlHelpers
         }
 
         [Test]
+        public void AspCommentRegex_Matches_Expression_With_Multi_Line_Content()
+        {
+            var inputText = $"{WebFormsCommentStartTag} {MultiLineExpressionContent} {WebFormsCommentEndTag}";
+
+            Assert.True(EmbeddedCodeReplacers.AspCommentRegex.IsMatch(inputText));
+        }
+
+        [Test]
         public void AspCommentRegex_Does_Not_Match_Expressions_With_Malformed_Tag_Braces()
         {
             var inputText = $"{WebFormsCommentStartTag} {NormalExpressionContent} {WebFormsMalformedCommentEndTag}";
@@ -181,6 +230,14 @@ namespace CTA.WebForms.Tests.Helpers.ControlHelpers
         public void EmbeddedCodeBlockRegex_Matches_Expressions_With_Characters_Mutual_To_Tag_Braces()
         {
             var inputText = $"{WebFormsCodeBlockStartTag} {MutualTagCharExpressionContent} {WebFormsNormalEndTag}";
+
+            Assert.True(EmbeddedCodeReplacers.EmbeddedCodeBlockRegex.IsMatch(inputText));
+        }
+
+        [Test]
+        public void EmbeddedCodeBlockRegex_Matches_Expression_With_Multi_Line_Content()
+        {
+            var inputText = $"{WebFormsCodeBlockStartTag} {MultiLineExpressionContent} {WebFormsNormalEndTag}";
 
             Assert.True(EmbeddedCodeReplacers.EmbeddedCodeBlockRegex.IsMatch(inputText));
         }


### PR DESCRIPTION
- Issue discovered where old regexes had issues dealing with content containing newlines
- Added single line regex option to embedded code replacer regexes as a fix
- Added tests for multiline content regex matching

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
