### PR TITLE
Added Using To Startup File Construction

### DIFF
--- a/src/CTA.WebForms/Helpers/StartupSyntaxHelper.cs
+++ b/src/CTA.WebForms/Helpers/StartupSyntaxHelper.cs
@@ -17,7 +17,8 @@ namespace CTA.WebForms.Helpers
             "Microsoft.AspNetCore.Hosting",
             "Microsoft.AspNetCore.Builder",
             "Microsoft.Extensions.Configuration",
-            "Microsoft.Extensions.DependencyInjection"
+            "Microsoft.Extensions.DependencyInjection",
+            "Microsoft.Extensions.Hosting"
         };
 
         /// <summary>

--- a/tst/CTA.Rules.Test/Models/ExpectedOutputConstants.cs
+++ b/tst/CTA.Rules.Test/Models/ExpectedOutputConstants.cs
@@ -1677,6 +1677,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace ASP.NET_WebForms
 {

--- a/tst/CTA.Rules.Test/Models/WebFormsFullExpectedOutputConstants.cs
+++ b/tst/CTA.Rules.Test/Models/WebFormsFullExpectedOutputConstants.cs
@@ -147,6 +147,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.EntityFrameworkCore;
 
 namespace WebFormsFull

--- a/tst/CTA.WebForms.Tests/ClassConverters/GlobalClassConverterTests.cs
+++ b/tst/CTA.WebForms.Tests/ClassConverters/GlobalClassConverterTests.cs
@@ -52,6 +52,7 @@ namespace CTA.WebForms.Tests.ClassConverters
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace ProjectNamespace
 {


### PR DESCRIPTION
## Description
Another quick fix

Added a using statement for Microsoft.Extensions.Hosting in Startup class
generation which defines the IWebHostingEnvironment.IsDevelopment() method
which is added to the generated Startup class

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
