### PR TITLE
POC for Argument Reuse

### DIFF
--- a/src/CTA.Rules.Actions/InvocationExpressionActions.cs
+++ b/src/CTA.Rules.Actions/InvocationExpressionActions.cs
@@ -88,9 +88,23 @@ namespace CTA.Rules.Actions
         /// <returns></returns>
         public Func<SyntaxGenerator, InvocationExpressionSyntax, InvocationExpressionSyntax> GetReplaceMethodAndParametersAction(string oldMethod, string newMethod, string newParameters)
         {
+            const string oldParam1EscapeKeyWord = "****OLDPARAM1****";
+            const string oldParam2EscapeKeyWord = "****OLDPARAM2****";
+
             //TODO what's the outcome if newMethod doesn't have a valid signature.. are there any options we could provide to parseexpression ?
             InvocationExpressionSyntax ReplaceOnlyMethod(SyntaxGenerator syntaxGenerator, InvocationExpressionSyntax node)
             {
+                if (newParameters.Contains(oldParam1EscapeKeyWord))
+                {
+                    var oldParam1 = node.ArgumentList.Arguments.First().ToFullString();
+                    newParameters = newParameters.Replace(oldParam1EscapeKeyWord, oldParam1);
+                }
+                if (newParameters.Contains(oldParam2EscapeKeyWord))
+                {
+                    var oldParam2 = node.ArgumentList.Arguments.Skip(1).First().ToFullString();
+                    newParameters = newParameters.Replace(oldParam2EscapeKeyWord, oldParam2);
+                }
+                
                 node = node.WithExpression(SyntaxFactory.ParseExpression(node.Expression.ToString().Replace(oldMethod, newMethod)))
                     .WithArgumentList(SyntaxFactory.ParseArgumentList(newParameters))
                     .WithLeadingTrivia(node.GetLeadingTrivia())

--- a/tst/CTA.Rules.Test/Actions/InvocationExpressionActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/InvocationExpressionActionsTests.cs
@@ -66,12 +66,12 @@ namespace CTA.Rules.Test.Actions
         public void GetReplaceMethodAndParametersAction()
         {
             const string newMethod = "Floor";
-            const string newParameter = "(-2)";
+            const string newParameter = "(****OLDPARAM1****)";
             var replaceMethodFunc =
                 _invocationExpressionActions.GetReplaceMethodAndParametersAction("Abs", newMethod, newParameter);
             var newNode = replaceMethodFunc(_syntaxGenerator, _node);
 
-            var expectedResult = "/* Comment */\r\nMath.Floor(-2)";
+            var expectedResult = "/* Comment */\r\nMath.Floor(-1)";
             Assert.AreEqual(expectedResult, newNode.ToFullString());
         }
 


### PR DESCRIPTION
This is just to show one concept for how to reuse arguments related to an issue with rule "Replace Owin.IAppBuilder.Use(object, params object[]) with .UseOwin." which shows up in failing OwinParadise tests using codelyzer 2.0.3

Maybe we already do this generically somewhere or this is supported somehow? I still don't know the code well enough to know if we already do something like this. 