### PR TITLE
Get semantic model with FullPath

### DIFF
--- a/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
+++ b/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
@@ -42,11 +42,11 @@ namespace CTA.WebForms.FileConverters
             try
             {
                 _fileModel = _webFormsProjectAnaylzer.AnalyzerResult.ProjectBuildResult?.SourceFileBuildResults?
-                    .Single(r => r.SourceFileFullPath.EndsWith(RelativePath))?.SemanticModel;
+                    .Single(r => r.SourceFileFullPath == FullPath)?.SemanticModel;
             }
             catch (Exception e)
             {
-                LogHelper.LogError(e, $"{Rules.Config.Constants.WebFormsErrorTag}Exception occurred when trying to retrieve semantic model for the file {RelativePath}. " +
+                LogHelper.LogError(e, $"{Rules.Config.Constants.WebFormsErrorTag}Exception occurred when trying to retrieve semantic model for the file {FullPath}. " +
                                       "Semantic Model will default to null.");
             }
 

--- a/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
+++ b/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
@@ -42,7 +42,7 @@ namespace CTA.WebForms.FileConverters
             try
             {
                 _fileModel = _webFormsProjectAnaylzer.AnalyzerResult.ProjectBuildResult?.SourceFileBuildResults?
-                    .Single(r => r.SourceFileFullPath == FullPath)?.SemanticModel;
+                    .Single(r => r.SourceFileFullPath.Equals(fullPath, StringComparison.OrdinalIgnoreCase))?.SemanticModel;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Related issue

Closes: #511 

## Description
* Use FullPath instead of RelativePath when searching for semantic model (current search function will return multiple semantic models in rare cases where two files share the same name).

## Supplemental testing
* This fix was tested and verified manually. Unit tests might not work here because the entity to test (semantic model) is private.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
