### PR TITLE
Always initialize classConverters collection

### DIFF
--- a/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
+++ b/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
@@ -57,7 +57,7 @@ namespace CTA.WebForms.FileConverters
             else
             {
                 _classConverters = new List<ClassConverter>();
-                LogHelper.LogWarning("Semantic model was found so class conversion cannot take place. Returning zero class converters.");
+                LogHelper.LogWarning($"Semantic model was not found so class conversion cannot take place. Returning zero class converters for file: {FullPath}");
             }
         }
 

--- a/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
+++ b/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
@@ -49,10 +49,15 @@ namespace CTA.WebForms.FileConverters
                 LogHelper.LogError(e, $"{Rules.Config.Constants.WebFormsErrorTag}Exception occurred when trying to retrieve semantic model for the file {FullPath}. " +
                                       "Semantic Model will default to null.");
             }
-
+            
             if (_fileModel != null)
             {
-                _classConverters = classConverterFactory.BuildMany(RelativePath, _fileModel);
+                _classConverters = _classConverterFactory.BuildMany(RelativePath, _fileModel);
+            }
+            else
+            {
+                _classConverters = new List<ClassConverter>();
+                LogHelper.LogWarning("Semantic model was found so class conversion cannot take place. Returning zero class converters.");
             }
         }
 


### PR DESCRIPTION
## Related issue

Closes: #513


## Description
* Initialize classConverters collection if semantic model is not found

## Supplemental testing
* Manually verified the expected behavior. Unable to unit test due to dependence on private members.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
