### PR TITLE
Check existence of files and directories before attempting deletion

### DIFF
--- a/src/CTA.FeatureDetection.Common/packages.lock.json
+++ b/src/CTA.FeatureDetection.Common/packages.lock.json
@@ -569,8 +569,8 @@
       },
       "NJsonSchema": {
         "type": "Transitive",
-        "resolved": "10.6.7",
-        "contentHash": "lZLJDlkjZ9lZ9XuEaTdlmXyZx0EQbrmU8MGFuAwXxGWJb4v0Zesnduta1KAs3RPCjUtFKheMWqmE1/411DUwzQ==",
+        "resolved": "10.6.8",
+        "contentHash": "/Sr08+VZVseYGN1o2PUO9BRAOtd78s6R/ks/9dc+HerDPnhU8/v382YKIOOJThD7HnahsuPAolcr3dh9m+ovnw==",
         "dependencies": {
           "Namotion.Reflection": "2.0.10",
           "Newtonsoft.Json": "9.0.1"
@@ -1689,7 +1689,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
-          "NJsonSchema": "10.6.7"
+          "NJsonSchema": "10.6.8"
         }
       }
     }

--- a/src/CTA.Rules.Config/CTA.Rules.Config.csproj
+++ b/src/CTA.Rules.Config/CTA.Rules.Config.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="NJsonSchema" Version="10.6.7" />
+    <PackageReference Include="NJsonSchema" Version="10.6.8s" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CTA.Rules.Config/CTA.Rules.Config.csproj
+++ b/src/CTA.Rules.Config/CTA.Rules.Config.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="NJsonSchema" Version="10.6.8s" />
+    <PackageReference Include="NJsonSchema" Version="10.6.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CTA.Rules.Models/packages.lock.json
+++ b/src/CTA.Rules.Models/packages.lock.json
@@ -575,8 +575,8 @@
       },
       "NJsonSchema": {
         "type": "Transitive",
-        "resolved": "10.6.7",
-        "contentHash": "lZLJDlkjZ9lZ9XuEaTdlmXyZx0EQbrmU8MGFuAwXxGWJb4v0Zesnduta1KAs3RPCjUtFKheMWqmE1/411DUwzQ==",
+        "resolved": "10.6.8",
+        "contentHash": "/Sr08+VZVseYGN1o2PUO9BRAOtd78s6R/ks/9dc+HerDPnhU8/v382YKIOOJThD7HnahsuPAolcr3dh9m+ovnw==",
         "dependencies": {
           "Namotion.Reflection": "2.0.10",
           "Newtonsoft.Json": "9.0.1"
@@ -1695,7 +1695,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
-          "NJsonSchema": "10.6.7"
+          "NJsonSchema": "10.6.8"
         }
       }
     }

--- a/src/CTA.WebForms/CTA.WebForms.csproj
+++ b/src/CTA.WebForms/CTA.WebForms.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.40" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CTA.WebForms/ProjectManagement/ProjectBuilder.cs
+++ b/src/CTA.WebForms/ProjectManagement/ProjectBuilder.cs
@@ -67,42 +67,47 @@ namespace CTA.WebForms.ProjectManagement
             }
         }
 
-        public void DeleteDirectoriesIfEmpty(string fullPath, string pathLimit)
+        public void DeleteDirectoriesIfEmpty(string directory, string pathLimit)
         {
-            if (fullPath == null)
+            if (directory == null || !Directory.Exists(directory))
             {
                 return;
             }
 
             try
             {
-                var beforePathLimit = FilePathHelper.IsSubDirectory(pathLimit, fullPath);
-                var directoryEmpty = !Directory.EnumerateFileSystemEntries(fullPath).Any();
+                var beforePathLimit = FilePathHelper.IsSubDirectory(pathLimit, directory);
+                var directoryEmpty = !Directory.EnumerateFileSystemEntries(directory).Any();
 
                 if (beforePathLimit && directoryEmpty)
                 {
-                    var parentDir = Path.GetDirectoryName(fullPath);
-                    Directory.Delete(fullPath);
+                    var parentDir = Path.GetDirectoryName(directory);
+                    Directory.Delete(directory);
                     DeleteDirectoriesIfEmpty(parentDir, pathLimit);
                 }
             }
             catch (Exception e)
             {
-                LogHelper.LogError(e, $"{Rules.Config.Constants.WebFormsErrorTag}Could not delete directory at {fullPath}");
+                LogHelper.LogError(e, $"{Rules.Config.Constants.WebFormsErrorTag}Could not delete directory at {directory}");
             }
         }
 
-        public void DeleteFileAndEmptyDirectories(string fullPath, string pathLimit)
+        public void DeleteFileAndEmptyDirectories(string filePath, string pathLimit)
         {
+            if (!File.Exists(filePath))
+            {
+                return;
+            }
+
             try
             {
-                var parentDir = Path.GetDirectoryName(fullPath);
-                File.Delete(fullPath);
+                var parentDir = Path.GetDirectoryName(filePath);
+                File.Delete(filePath);
                 DeleteDirectoriesIfEmpty(parentDir, pathLimit);
             }
             catch (Exception e)
             {
-                LogHelper.LogError(e, $"{Rules.Config.Constants.WebFormsErrorTag}Unable to delete file at {fullPath}");
+                LogHelper.LogError(e, $"{Rules.Config.Constants.WebFormsErrorTag}Unable to delete file at {filePath}");
             }
         }
     }

--- a/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
+++ b/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
@@ -216,17 +216,6 @@ namespace CTA.Rules.Test
             }
         }
 
-        public string DownloadTestProjects(string tempDir)
-        {
-            var tempDirectory = Directory.CreateDirectory(tempDir);
-            string downloadLocation = Path.Combine(tempDirectory.FullName, "d");
-
-            var fileName = Path.Combine(tempDirectory.Parent.FullName, @"TestProjects.zip");
-            Utils.SaveFileFromGitHub(fileName, GithubInfo.TestGithubOwner, GithubInfo.TestGithubRepo, GithubInfo.TestGithubTag);
-            ZipFile.ExtractToDirectory(fileName, downloadLocation, true);
-            return downloadLocation;
-        }
-
         protected void CopyDirectory(DirectoryInfo source, DirectoryInfo target)
         {
             if (!Directory.Exists(target.FullName))
@@ -248,15 +237,15 @@ namespace CTA.Rules.Test
             }
         }
 
-        protected string CopySolutionFolderToTemp(string solutionName, string tempDir)
+        protected string CopySolutionFolderToTemp(string solutionName, string searchDir)
         {
-            string solutionPath = Directory.EnumerateFiles(tempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault(s => !s.Contains(string.Concat(Path.DirectorySeparatorChar, CopyFolder, Path.DirectorySeparatorChar)));
-            string solutionDir = Directory.GetParent(solutionPath).FullName;
+            var solutionPath = Directory.EnumerateFiles(searchDir, solutionName, SearchOption.AllDirectories).FirstOrDefault(s => !s.Contains(string.Concat(Path.DirectorySeparatorChar, CopyFolder, Path.DirectorySeparatorChar)));
+            var solutionDir = Directory.GetParent(solutionPath).FullName;
             var newTempDir = Path.Combine(GetTstPath(this.GetType()), CopyFolder, Guid.NewGuid().ToString());
             CopyDirectory(new DirectoryInfo(solutionDir), new DirectoryInfo(newTempDir));
 
-            solutionPath = Directory.EnumerateFiles(newTempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault();
-            return solutionPath;
+            var newSolutionPath = Directory.EnumerateFiles(newTempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault();
+            return newSolutionPath;
         }
 
 

--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -1,10 +1,8 @@
 ﻿using CTA.Rules.Test.Models;
 using NUnit.Framework;
-using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace CTA.Rules.Test
 {
@@ -27,7 +25,7 @@ namespace CTA.Rules.Test
         {
             TestSolutionAnalysis results = AnalyzeSolution("AspNetRoutes.sln", tempDir, downloadLocation, version);
 
-            string projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
+            var projectDir = results.ProjectResults.FirstOrDefault().ProjectDirectory;
             var csProjContent = results.ProjectResults.FirstOrDefault().CsProjectContent;
 
             var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));

--- a/tst/CTA.Rules.Test/OwinTests.cs
+++ b/tst/CTA.Rules.Test/OwinTests.cs
@@ -38,8 +38,8 @@ namespace CTA.Rules.Test
             //StringAssert.Contains(@"Microsoft.AspNetCore.Hosting", programText);
             //StringAssert.Contains(@"Microsoft.Extensions.Hosting;", programText);
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.AspNetRoutesOwinApp2, owinapp2Text);
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.AspNetRoutesStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.AspNetRoutesOwinApp2.NormalizeNewLineChars(), owinapp2Text.NormalizeNewLineChars());
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.AspNetRoutesStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             StringAssert.Contains(@"Microsoft.AspNetCore.Owin", csProjContent);
             StringAssert.Contains(@"Microsoft.AspNetCore.Diagnostics", csProjContent);
@@ -51,8 +51,6 @@ namespace CTA.Rules.Test
             //Check that correct version is used
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
         }
-
-
 
         [TestCase(TargetFramework.Dotnet6)]
         [TestCase(TargetFramework.Dotnet5)]
@@ -68,9 +66,9 @@ namespace CTA.Rules.Test
             var displayText = File.ReadAllText(Path.Combine(projectDir, "DisplayBreadCrumbs.cs"));
             var addText = File.ReadAllText(Path.Combine(projectDir, "AddBreadCrumbMiddleware.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.BranchingPipelinesDisplayBreadCrumbs, displayText);
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.BranchingPipelinesAddBreadCrumbMiddleware, addText);
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.BranchingPipelinesStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.BranchingPipelinesDisplayBreadCrumbs.NormalizeNewLineChars(), displayText.NormalizeNewLineChars());
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.BranchingPipelinesAddBreadCrumbMiddleware.NormalizeNewLineChars(), addText.NormalizeNewLineChars());
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.BranchingPipelinesStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             //Check that package has been added:
             StringAssert.Contains(@"Microsoft.AspNetCore.Owin", csProjContent);
@@ -96,8 +94,8 @@ namespace CTA.Rules.Test
             var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
             var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.EmbeddedStartup, startupText);
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.EmbeddedProgram, programText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.EmbeddedStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.EmbeddedProgram.NormalizeNewLineChars(), programText.NormalizeNewLineChars());
 
             //Check that package has been added:
             StringAssert.Contains(@"Microsoft.AspNetCore.Owin", csProjContent);
@@ -125,8 +123,8 @@ namespace CTA.Rules.Test
             var startupText = File.ReadAllText(Path.Combine(myApp.ProjectDirectory, "Startup.cs"));
             var programText = File.ReadAllText(Path.Combine(myApp.ProjectDirectory, "Program.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.CustomServerProgram, programText);
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.CustomServerStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.CustomServerProgram.NormalizeNewLineChars(), programText.NormalizeNewLineChars());
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.CustomServerStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             //Check for comment on how to implement a custom server here in program
 
@@ -165,7 +163,7 @@ namespace CTA.Rules.Test
 
             var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.HelloWorldStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.HelloWorldStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             //Check that package has been added:
             StringAssert.Contains(@"Microsoft.AspNetCore.Owin", csProjContent);
@@ -186,7 +184,7 @@ namespace CTA.Rules.Test
             var csProjContent = results.ProjectResults.FirstOrDefault().CsProjectContent;
             var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.HelloWorldRawOwinStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.HelloWorldRawOwinStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             //Check that package has been added:
             StringAssert.Contains(@"Microsoft.AspNetCore.Diagnostics", csProjContent);
@@ -207,8 +205,8 @@ namespace CTA.Rules.Test
             var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
             var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinSelfHostProgram, programText);
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinSelfHostStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinSelfHostProgram.NormalizeNewLineChars(), programText.NormalizeNewLineChars());
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinSelfHostStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             //Check that package has been added:
             StringAssert.Contains(@"Microsoft.AspNetCore.Diagnostics", csProjContent);
@@ -231,8 +229,8 @@ namespace CTA.Rules.Test
             var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
             var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.SignalRProgram, programText);
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.SignalRStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.SignalRProgram.NormalizeNewLineChars(), programText.NormalizeNewLineChars());
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.SignalRStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             //Check that package has been added:
             StringAssert.Contains(@"Microsoft.AspNetCore.Diagnostics", csProjContent);
@@ -256,8 +254,8 @@ namespace CTA.Rules.Test
             var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
             var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.StaticFilesSampleProgram, programText);
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.StaticFilesSampleStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.StaticFilesSampleProgram.NormalizeNewLineChars(), programText.NormalizeNewLineChars());
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.StaticFilesSampleStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             //Check that package has been added:
             StringAssert.Contains(@"Microsoft.AspNetCore.Diagnostics", csProjContent);
@@ -282,7 +280,7 @@ namespace CTA.Rules.Test
             var csProjContent = results.ProjectResults.FirstOrDefault().CsProjectContent;
             var startupText = File.ReadAllText(Path.Combine(projectDir, "Startup.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinWebApiStartup, startupText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinWebApiStartup.NormalizeNewLineChars(), startupText.NormalizeNewLineChars());
 
             //Check that package has been added:
             StringAssert.Contains(new []{TargetFramework.Dotnet5, TargetFramework.Dotnet6}.Contains(version) 
@@ -343,7 +341,7 @@ namespace CTA.Rules.Test
 
             var programText = File.ReadAllText(Path.Combine(projectDir, "Program.cs"));
 
-            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinExtraAPIProgram, programText);
+            StringAssert.AreEqualIgnoringCase(ExpectedOutputConstants.OwinExtraAPIProgram.NormalizeNewLineChars(), programText.NormalizeNewLineChars());
 
             //Check that correct version is used
             Assert.True(csProjContent.IndexOf(string.Concat(">", version, "<")) > 0);
@@ -362,6 +360,5 @@ namespace CTA.Rules.Test
             var buildErrors = GetSolutionBuildErrors(results.SolutionRunResult.SolutionPath);
             Assert.AreEqual(0, buildErrors.Count);
         }
-
     }
 }

--- a/tst/CTA.Rules.Test/TestUtils.cs
+++ b/tst/CTA.Rules.Test/TestUtils.cs
@@ -19,4 +19,14 @@ namespace CTA.Rules.Test
             return method;
         }
     }
+    
+    internal static class StringExtensions
+    {
+        public static string NormalizeNewLineChars(this string toNormalize)
+        {
+            return toNormalize
+                .Replace("\r\n", "\n")
+                .Replace("\n", Environment.NewLine);
+        }
+    }
 }

--- a/tst/CTA.Rules.Test/WebFormsFullTests.cs
+++ b/tst/CTA.Rules.Test/WebFormsFullTests.cs
@@ -38,13 +38,6 @@ namespace CTA.Rules.Test
             };
         }
 
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            tempDir = SetupTests.TempDir;
-            downloadLocation = SetupTests.DownloadLocation;
-        }
-
         [TestCase(TargetFramework.DotnetCoreApp31)]
         [TestCase(TargetFramework.Dotnet5)]
         [TestCase(TargetFramework.Dotnet6)]

--- a/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
+++ b/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
@@ -50,9 +50,9 @@ namespace CTA.WebForms.Tests.FileConverters.DownloadRequired
         private void DownloadTestProjects()
         {
             var tempDirectory = Directory.CreateDirectory(_tempDir);
-            _downloadLocation = Path.Combine(tempDirectory.FullName, "d");
+            _downloadLocation = Path.Combine(tempDirectory.FullName, "w2b");
 
-            var fileName = Path.Combine(tempDirectory.Parent.FullName, @"TestProjects.zip");
+            var fileName = Path.Combine(tempDirectory.FullName, @"TestProjects.zip");
             Utils.SaveFileFromGitHub(fileName, GithubInfo.TestGithubOwner, GithubInfo.TestGithubRepo,
                 GithubInfo.TestGithubTag);
             ZipFile.ExtractToDirectory(fileName, _downloadLocation, true);

--- a/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
+++ b/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
@@ -13,7 +13,7 @@ namespace CTA.WebForms.Tests.FileConverters.DownloadRequired
     public class DownloadTestProjectsFixture : AwsRulesBaseTest
     {
         private string _tempDir;
-        private string _copyFolder;
+        private string _testRunFolder;
         private string _downloadLocation;
         private static string _eShopOnBlazorSolutionFilePath;
         private static string _eShopOnBlazorSolutionPath;
@@ -30,10 +30,11 @@ namespace CTA.WebForms.Tests.FileConverters.DownloadRequired
             _tempDir = GetTstPath(Path.Combine(new[] {"Projects", "Temp", "W2B"}));
             DownloadTestProjects();
 
+            var targetDir = "w2b";
             _eShopOnBlazorSolutionFilePath = CopySolutionFolderToTemp("eShopOnBlazor.sln", _tempDir);
             _eShopOnBlazorSolutionPath = Directory.GetParent(EShopOnBlazorSolutionFilePath).FullName;
 
-            _copyFolder = Directory.GetParent(EShopOnBlazorSolutionPath).FullName;
+            _testRunFolder = Directory.GetParent(EShopOnBlazorSolutionPath).FullName;
 
             _eShopLegacyWebFormsProjectPath = Utils.GetProjectPaths(EShopOnBlazorSolutionPath)
                 .First(filePath =>
@@ -65,7 +66,7 @@ namespace CTA.WebForms.Tests.FileConverters.DownloadRequired
                 try
                 {
                     Directory.Delete(_tempDir, true);
-                    Directory.Delete(_copyFolder, true);
+                    Directory.Delete(_testRunFolder, true);
                 }
                 catch (Exception)
                 {

--- a/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
+++ b/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
@@ -30,7 +30,6 @@ namespace CTA.WebForms.Tests.FileConverters.DownloadRequired
             _tempDir = GetTstPath(Path.Combine(new[] {"Projects", "Temp", "W2B"}));
             DownloadTestProjects();
 
-            var targetDir = "w2b";
             _eShopOnBlazorSolutionFilePath = CopySolutionFolderToTemp("eShopOnBlazor.sln", _tempDir);
             _eShopOnBlazorSolutionPath = Directory.GetParent(EShopOnBlazorSolutionFilePath).FullName;
             _testRunFolder = EShopOnBlazorSolutionPath;

--- a/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
+++ b/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
@@ -33,8 +33,7 @@ namespace CTA.WebForms.Tests.FileConverters.DownloadRequired
             var targetDir = "w2b";
             _eShopOnBlazorSolutionFilePath = CopySolutionFolderToTemp("eShopOnBlazor.sln", _tempDir);
             _eShopOnBlazorSolutionPath = Directory.GetParent(EShopOnBlazorSolutionFilePath).FullName;
-
-            _testRunFolder = Directory.GetParent(EShopOnBlazorSolutionPath).FullName;
+            _testRunFolder = EShopOnBlazorSolutionPath;
 
             _eShopLegacyWebFormsProjectPath = Utils.GetProjectPaths(EShopOnBlazorSolutionPath)
                 .First(filePath =>


### PR DESCRIPTION
## Related issue

Closes: #ISSUE_NUMBER_HERE


## Description
* During Web Forms conversion, check that directories and files exist before attempting deletion. This will prevent excessive error logging.
* Upgrade nuget packages `NJsonSchema` and `HTMLAgilityPack` to their latest versions
* Resolve race condition where test project files used in the CTA conversion tests were being deleted by the Web Forms conversion tests, causing unit test failures in the CI/CD pipeline

## Supplemental testing
* Manually tested
* Unable to add unit test for exception throwing because the exception is caught within the function

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
