### PR TITLE
Make program.cs public to allow invoking the cli from different projects

### DIFF
--- a/src/CTA.Rules.Update/Program.cs
+++ b/src/CTA.Rules.Update/Program.cs
@@ -10,9 +10,9 @@ using Microsoft.Extensions.Logging;
 namespace CTA.Rules.Update
 {
     [ExcludeFromCodeCoverage]
-    class Program
+    public class Program
     {
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {
             try
             {


### PR DESCRIPTION
Make program.cs public to allow invoking the cli from different projects