### PR TITLE
fix: SyntaxNodeExtension NoComments function is not removing all comments

### DIFF
--- a/src/CTA.FeatureDetection.Common/Extensions/SyntaxNodeExtensions.cs
+++ b/src/CTA.FeatureDetection.Common/Extensions/SyntaxNodeExtensions.cs
@@ -7,13 +7,21 @@ namespace CTA.FeatureDetection.Common.Extensions
 {
     public static class SyntaxNodeExtensions
     {
+        // A syntax tree has SyntaxNodes, SyntaxTokens and SyntaxTrivia, for more detail please refer to link below.
+        // https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/get-started/syntax-analysis
+        // This function is to remove all comments from the syntax tree, which it needs to iterate and replaces all
+        // SyntaxNodes and SyntaxTokens to so no comments or white spaces are in the tree anymore.
         public static SyntaxNode NoComments(this SyntaxNode node)
         {
             if (node != null)
             {
-                var childNodes = node.ChildNodes();
-                node = node.ReplaceNodes(childNodes, (node, returnedNode) => node.NoComments());
                 node = node.WithoutTrivia();
+
+                var childNodes = node.ChildNodes();
+                node = node.ReplaceNodes(childNodes, (oldNode, _) => oldNode.NoComments());
+
+                var childTokens = node.ChildTokens();
+                node = node.ReplaceTokens(childTokens, (oldToken, _) => oldToken.WithoutTrivia());
             }
             return node;
         }


### PR DESCRIPTION
## Action execution validation errors after ReplaceIdentifier or ReplaceMethodWithObjectAddType.

Closes: #ISSUE_NUMBER_HERE


## Description
* CTA is to validate the target code against the source code after each conversion, so to make sure target code doesn't contain any keywords that are not expected. It is done by reconstruct a syntax tree without any comments. The existing function is only removing comments from SyntaxNodes but not removing comments from SyntaxTokens. This PR is to make sure all comments or white spaces are removed properly so the validation only consider code but not comment area for any error reports.

## Supplemental testing
Source code:
![Screen Shot 2022-02-16 at 10 34 58 PM](https://user-images.githubusercontent.com/34224380/154419172-352d8cb9-86c1-4a3f-bf80-d55d328f8bb6.png)

Before the change after calling NoComments function:
![Screen Shot 2022-02-16 at 10 34 23 PM](https://user-images.githubusercontent.com/34224380/154419103-3d817418-de46-45ee-80aa-f0ecc2c4faac.png)

After the change after calling NoComments function:
![Screen Shot 2022-02-16 at 10 32 30 PM](https://user-images.githubusercontent.com/34224380/154418942-6be4ca25-03eb-49e2-9756-fe51d7e97fa0.png)

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
