### PR TITLE
Create separate action for adding web api controller calls

### DIFF
--- a/src/CTA.Rules.Actions/ProjectLevelActions.cs
+++ b/src/CTA.Rules.Actions/ProjectLevelActions.cs
@@ -106,31 +106,45 @@ namespace CTA.Rules.Actions
         {
             string func(string projectDir, ProjectType projectType)
             {
-                if(projectDir != null && projectDir.Length > 0)
-                {
-                    if(string.Equals(Path.GetFileNameWithoutExtension(projectDir), projectName))
-                    {
-                        UpdateCsprojReference(projectDir);
-
-                        var pathOnly = Path.GetDirectoryName(projectDir);
-                        var file = Path.Combine(pathOnly, string.Concat(FileTypeCreation.MonolithService.ToString(), ".cs"));
-                        if (File.Exists(file))
-                        {
-                            if (File.Exists(string.Concat(file, ".bak")))
-                            {
-                                File.Delete(string.Concat(file, ".bak"));
-                            }
-                            File.Move(file, string.Concat(file, ".bak"));
-                        }
-                        File.WriteAllText(file, TemplateHelper.GetTemplateFileContent(namespaceString, ProjectType.MonolithService, FileTypeCreation.MonolithService.ToString() + ".cs"));
-
-                        LogHelper.LogInformation(string.Format("Created {0}.cs file using {1} template", FileTypeCreation.MonolithService.ToString(), ProjectType.MonolithService.ToString()));
-                    }
-                }
-
+                AddMonolithFile(namespaceString, projectName, projectDir, projectType, FileTypeCreation.MonolithServiceMvc.ToString());
                 return "";
             }
             return func;
+        }
+
+        public Func<string, ProjectType, string> GetCreateMonolithServiceWebAPIAction(string namespaceString, string projectName)
+        {
+            string func(string projectDir, ProjectType projectType)
+            {
+                AddMonolithFile(namespaceString, projectName, projectDir, projectType, FileTypeCreation.MonolithService.ToString());
+                return "";
+            }
+            return func;
+        }
+
+        private void AddMonolithFile(string namespaceString, string projectName, string projectDir, ProjectType projectType, string templateFilename)
+        {
+            if (projectDir != null && projectDir.Length > 0)
+            {
+                if (string.Equals(Path.GetFileNameWithoutExtension(projectDir), projectName))
+                {
+                    UpdateCsprojReference(projectDir);
+                    var pathOnly = Path.GetDirectoryName(projectDir);
+                    var file = Path.Combine(pathOnly, string.Concat(templateFilename, ".cs"));
+                    if (File.Exists(file))
+                    {
+                        if (File.Exists(string.Concat(file, ".bak")))
+                        {
+                            File.Delete(string.Concat(file, ".bak"));
+                        }
+                        File.Move(file, string.Concat(file, ".bak"));
+                    }
+                    File.WriteAllText(file, TemplateHelper.GetTemplateFileContent(namespaceString, ProjectType.MonolithService, templateFilename + ".cs"));
+                    LogHelper.LogInformation(string.Format("Created {0}.cs file using {1} template", templateFilename, ProjectType.MonolithService.ToString()));
+
+                }
+            }
+
         }
 
         private void UpdateCsprojReference(string projectFile)

--- a/src/CTA.Rules.Config/Constants.cs
+++ b/src/CTA.Rules.Config/Constants.cs
@@ -130,6 +130,7 @@ namespace CTA.Rules.Config
         public const string Public = "public";
         public const string DotResult = ".Result";
         public const string MonolithService = "MonolithService";
+        public const string MonolithServiceMvc = "MonolithServiceMvc";
         public const string MonolithServiceComment = "Modified to call the extracted logic.";
 
 
@@ -143,6 +144,7 @@ namespace CTA.Rules.Config
             new List<string> {"mvc","Program.cs"},
             new List<string> {"mvc","Startup.cs" },
             new List<string> {"monolithservice","MonolithService.cs" },
+            new List<string> {"monolithservice","MonolithServiceMvc.cs" },
             new List<string> {"webclasslibrary","appsettings.json" },
             new List<string> { "wcfcodebasedservice", "Program.cs"},
             new List<string> { "wcfcodebasedservice", "Startup.cs"},

--- a/src/CTA.Rules.Models/Enums.cs
+++ b/src/CTA.Rules.Models/Enums.cs
@@ -39,7 +39,8 @@
     {
         Startup,
         Program,
-        MonolithService
+        MonolithService,
+        MonolithServiceMvc
     }
     public enum WebServerConfigAttributes
     {

--- a/tst/CTA.Rules.Test/CTAFiles/project.specific.json
+++ b/tst/CTA.Rules.Test/CTAFiles/project.specific.json
@@ -24,7 +24,7 @@
       "Type": "Project",
       "Actions": [
         {
-          "Name": "CreateMonolithService",
+          "Name": "CreateMonolithServiceWebAPI",
           "Type": "Project",
           "Value": {
             "namespaceString": "SampleWebApi.Controllers",

--- a/tst/CTA.Rules.Test/CTATests.cs
+++ b/tst/CTA.Rules.Test/CTATests.cs
@@ -188,12 +188,12 @@ namespace CTA.Rules.Test
 
         [Test]
         public void TestMonolithReplacementsMVC()
-        {
+         {
             var results = runCTAFile("MvcMusicStore.sln").ProjectResults.FirstOrDefault();
 
             var storeManagerControllerText = File.ReadAllText(Path.Combine(results.ProjectDirectory, "Controllers", "StoreManagerController.cs"));
 
-            FileAssert.Exists(Path.Combine(results.ProjectDirectory, Constants.MonolithService + ".cs"));
+            FileAssert.Exists(Path.Combine(results.ProjectDirectory, Constants.MonolithServiceMvc + ".cs"));
             StringAssert.Contains(@"return Content(MonolithService.CreateRequest(Request, this.ControllerContext.RouteData));", storeManagerControllerText);
         }
 


### PR DESCRIPTION
Separate the action to create a monolithservice class between web api and other types of projects. This will make sure we add webapi calls only to projects that contains web api references.