### PR TITLE
Reverted to proper test rule and template use

### DIFF
--- a/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
+++ b/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
@@ -204,13 +204,11 @@ namespace CTA.Rules.Test
 
         private void CopyTestRules()
         {
-            var assemblyDir = Assembly.GetExecutingAssembly().Location;
-            var netVersionDir = Path.GetDirectoryName(assemblyDir);
-            var debugDir = Path.GetDirectoryName(netVersionDir);
-            var binDir = Path.GetDirectoryName(debugDir);
-            var projectDir = Path.GetDirectoryName(binDir);
+            // Set each file in the TempRules directory to copy to output directory using file
+            // properties menu or the test rules will not work
+            var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            var tempRulesDir = Path.Combine(projectDir, "TempRules");
+            var tempRulesDir = Path.Combine(assemblyDir, "TempRules");
             if (Directory.Exists(tempRulesDir))
             {
                 var files = Directory.EnumerateFiles(tempRulesDir, "*.json");
@@ -226,13 +224,11 @@ namespace CTA.Rules.Test
 
         private void CopyTestTemplates()
         {
-            var assemblyDir = Assembly.GetExecutingAssembly().Location;
-            var netVersionDir = Path.GetDirectoryName(assemblyDir);
-            var debugDir = Path.GetDirectoryName(netVersionDir);
-            var binDir = Path.GetDirectoryName(debugDir);
-            var projectDir = Path.GetDirectoryName(binDir);
+            // Set each file in the TempTemplates directory to copy to output directory using file
+            // properties menu or the test templates will not work
+            var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            var tempTemplatesDir = Path.Combine(projectDir, "TempTemplates");
+            var tempTemplatesDir = Path.Combine(assemblyDir, "TempTemplates");
             if (Directory.Exists(tempTemplatesDir))
             {
                 var files = Directory.EnumerateFiles(tempTemplatesDir, "*", SearchOption.AllDirectories);

--- a/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
+++ b/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
@@ -33,6 +33,12 @@
     <None Update="CTAFiles\action.namespace.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TempRules\project.all.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TempTemplates\webforms\appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
 	<None Update="TestFiles\Configs\Web.config">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</None>


### PR DESCRIPTION
 * Marked test rules and templates for copying to output directory
 * Changed copy methods for test rules and templates to use output directory
 * Added comments in copy methods that instruct to set the copy to output directory property on test rules and templates

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
