### PR TITLE
Add bouncycastle tests

### DIFF
--- a/src/CTA.Rules.Common/WebConfigManagement/WebConfigManager.cs
+++ b/src/CTA.Rules.Common/WebConfigManagement/WebConfigManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml.Linq;
 using CTA.Rules.Config;
@@ -19,6 +20,8 @@ namespace CTA.Rules.Common.WebConfigManagement
         private static Dictionary<string, XDocument> _xDocumentCache = new Dictionary<string, XDocument>();
         private delegate object ConfigLoadingDelegate(string configFile);
 
+        // Currently unused
+        [ExcludeFromCodeCoverage]
         public static Configuration LoadWebConfigAsConfiguration(string projectDir)
         {
             var config = LoadWebConfig(projectDir, webConfigFile =>

--- a/src/CTA.Rules.Config/Utils.cs
+++ b/src/CTA.Rules.Config/Utils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -95,6 +96,8 @@ namespace CTA.Rules.Config
         }
         public static string EscapeAllWhitespace(string src) => Regex.Replace(src, @"(\s+)|(\\n)|(\\r)|(\\t)|(\n)|(\r)|(\t)", string.Empty);
 
+        // Only used during manual testing so excluding from coverage
+        [ExcludeFromCodeCoverage]
         public static string DownloadFile(string fileUrl, string destinationFile, int retryCount = Constants.DownloadRetryCount)
         {
             int retryAttempts = 0;
@@ -191,7 +194,8 @@ namespace CTA.Rules.Config
             }
         }
 
-
+        // Used by CLI which is covered by integration tests
+        [ExcludeFromCodeCoverage]
         public static string CopySolutionToTemp(string solutionPath)
         {
             string slnDirPath = Directory.GetParent(solutionPath).FullName;
@@ -231,6 +235,8 @@ namespace CTA.Rules.Config
         /// <param name="tempDir">The folder the location resides in</param>
         /// <param name="destinationLocation">copied folder location</param>
         /// <returns></returns>
+        // Covered by CLI integration tests
+        [ExcludeFromCodeCoverage]
         public static string CopyFolderToTemp(string solutionName, string tempDir, string destinationLocation)
         {
             string solutionPath = Directory.EnumerateFiles(tempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault(s => !s.Contains(string.Concat(Path.DirectorySeparatorChar, Path.DirectorySeparatorChar)));
@@ -246,6 +252,8 @@ namespace CTA.Rules.Config
         /// </summary>
         /// <param name="source">Source directory</param>
         /// <param name="target">Destination directory</param>
+        // Covered by CLI integration tests
+        [ExcludeFromCodeCoverage]
         private static void CopyDirectory(DirectoryInfo source, DirectoryInfo target)
         {
             if (!Directory.Exists(target.FullName))
@@ -272,8 +280,6 @@ namespace CTA.Rules.Config
         {
             using var httpClient = new HttpClient();
 
-            var parallelOptions = new ParallelOptions() { MaxDegreeOfParallelism = Constants.ThreadCount };
-
             Parallel.ForEach(Constants.TemplateFiles, file =>
             {
                 var localFile = Path.Combine(targetFolder, string.Join(Path.DirectorySeparatorChar, file));
@@ -297,7 +303,7 @@ namespace CTA.Rules.Config
                 }
                 catch (Exception ex)
                 {
-                    LogHelper.LogError(ex, $"Error while dowloading file {file}");
+                    LogHelper.LogError(ex, $"Error while downloading file {file}");
                 }
             });
         }

--- a/src/CTA.Rules.PortCore/Program.cs
+++ b/src/CTA.Rules.PortCore/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using CTA.Rules.Config;
 using CTA.Rules.Models;
 using Microsoft.Extensions.Logging;

--- a/src/CTA.Rules.PortCore/ProjectSpecificPort/ProjectRewriters/PortCoreProjectRewriterFactory.cs
+++ b/src/CTA.Rules.PortCore/ProjectSpecificPort/ProjectRewriters/PortCoreProjectRewriterFactory.cs
@@ -18,7 +18,7 @@ namespace CTA.Rules.PortCore
             };
             return projectRewriter;
         }
-
+        
         public ProjectRewriter GetInstance(IDEProjectResult ideProjectResult, ProjectConfiguration projectConfiguration)
         {
             var projectType = projectConfiguration.ProjectType;

--- a/src/CTA.Rules.PortCore/ProjectSpecificPort/ProjectRewriters/WCFProjectRewriter.cs
+++ b/src/CTA.Rules.PortCore/ProjectSpecificPort/ProjectRewriters/WCFProjectRewriter.cs
@@ -55,7 +55,7 @@ namespace CTA.Rules.Update
 
             return _projectResult;
         }
-
+        
         public override List<IDEFileActions> RunIncremental(List<string> updatedFiles, RootNodes projectRules)
         {
             base.RunIncremental(updatedFiles, projectRules);

--- a/src/CTA.Rules.PortCore/SolutionPort.cs
+++ b/src/CTA.Rules.PortCore/SolutionPort.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -116,7 +117,7 @@ namespace CTA.Rules.PortCore
             _context = new MetricsContext(solutionFilePath, analyzerResults);
             InitSolutionRewriter(analyzerResults, solutionConfiguration);
         }
-
+        
         public SolutionPort(string solutionFilePath, IDEProjectResult projectResult, List<PortCoreConfiguration> solutionConfiguration)
         {
             _solutionPath = solutionFilePath;

--- a/src/CTA.Rules.Update/SolutionRewriter.cs
+++ b/src/CTA.Rules.Update/SolutionRewriter.cs
@@ -65,7 +65,7 @@ namespace CTA.Rules.Update
             _projectRewriters = new List<ProjectRewriter>();
             InitializeProjectRewriters(analyzerResults, solutionConfiguration);
         }
-
+        
         public SolutionRewriter(IDEProjectResult projectResult, List<ProjectConfiguration> solutionConfiguration, IProjectRewriterFactory projectRewriterFactory = null)
         {
             DownloadResourceFiles();

--- a/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
+++ b/tst/CTA.Rules.Test/AwsRulesBaseTest.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
+++ b/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
@@ -42,6 +42,12 @@
     <None Update="CTAFiles\action.namespace.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TempRules\project.all.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TempTemplates\webforms\appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
 	<None Update="TestFiles\Configs\Web.config">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</None>

--- a/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
+++ b/tst/CTA.WebForms.Tests/FileConverters/DownloadRequired/DownloadTestProjectsFixture.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace CTA.WebForms.Tests.FileConverters.DownloadRequired
 {
-    [SetUpFixture]
     public class DownloadTestProjectsFixture : AwsRulesBaseTest
     {
         private string _tempDir;

--- a/tst/CTA.WebForms.Tests/FileConverters/StaticFileConverterTests.cs
+++ b/tst/CTA.WebForms.Tests/FileConverters/StaticFileConverterTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using CTA.Rules.Metrics;
 using CTA.WebForms.FileConverters;
 using CTA.WebForms.FileInformationModel;
 using CTA.WebForms.Metrics;
@@ -11,7 +10,6 @@ using NUnit.Framework;
 
 namespace CTA.WebForms.Tests.FileConverters
 {
-    [TestFixture]
     public class StaticFileConverterTests
     {
         [Test]

--- a/tst/CTA.WebForms.Tests/TagConfigs/TagConfigsTestFixture.cs
+++ b/tst/CTA.WebForms.Tests/TagConfigs/TagConfigsTestFixture.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 
 namespace CTA.WebForms.Tests.TagConfigs
 {
-    [TestFixture]
     public class TagConfigsTestFixture : WebFormsTestBase
     {
         private protected TagConfigParser _tagConfigParser;

--- a/tst/CTA.WebForms.Tests/WebFormsTestBase.cs
+++ b/tst/CTA.WebForms.Tests/WebFormsTestBase.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 
 namespace CTA.WebForms.Tests
 {
-    [TestFixture]
     public class WebFormsTestBase
     {
         public static string AssemblyDir => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);


### PR DESCRIPTION
## Related issue

## Description
* Add tests to confirm BouncyCastle rules defined in https://github.com/aws/porting-assistant-dotnet-datastore/pull/143


## Additional context
* These tests were run locally by using the rules defined in https://github.com/aws/porting-assistant-dotnet-datastore/pull/143 and adding them to the CTA TempRules directory. The temp rules were excluded from this PR.
* Unit tests will fail until https://github.com/aws/porting-assistant-dotnet-datastore/pull/143 is merged.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
