### PR TITLE
Add source versions to CTA framework and metrics

### DIFF
--- a/src/CTA.Rules.Config/Constants.cs
+++ b/src/CTA.Rules.Config/Constants.cs
@@ -28,6 +28,7 @@ namespace CTA.Rules.Config
         public static string ResourcesExtractedPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Templates"));
         public static string TagConfigsExtractedPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TagConfigs"));
         public static string DefaultCoreVersion = "netcoreapp3.1";
+        public static string DefaultNetFrameworkVersion = "net48";
 
         public static string JsonFileSchema = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), Path.Combine(new string[] { "..", "..", "..", "..", ".." })
         , Path.Combine(new string[] { "src", "CTA.Rules.RuleFiles", "Schema", "schema.validator.json" })));

--- a/src/CTA.Rules.Metrics/MetricsTransformer.cs
+++ b/src/CTA.Rules.Metrics/MetricsTransformer.cs
@@ -54,9 +54,15 @@ namespace CTA.Rules.Metrics
             var targetVersions = projectResult.TargetVersions;
             var sourceVersions = projectResult.SourceVersions;
             var targetVersionMetrics = new List<TargetVersionMetric>();
+
             for (int i = 0; i < targetVersions.Count; i++)
             {
-                targetVersionMetrics.Add(new TargetVersionMetric(context, targetVersions[i], projectFile, sourceVersions[i]??null));
+                string sourceVersion = null;
+                if (targetVersions.Count == sourceVersions.Count)
+                {
+                    sourceVersion = sourceVersions[i];
+                }
+                targetVersionMetrics.Add(new TargetVersionMetric(context, targetVersions[i], projectFile, sourceVersion));
             }
 
             return targetVersionMetrics;

--- a/src/CTA.Rules.Metrics/MetricsTransformer.cs
+++ b/src/CTA.Rules.Metrics/MetricsTransformer.cs
@@ -52,10 +52,11 @@ namespace CTA.Rules.Metrics
         {
             var projectFile = projectResult.ProjectFile;
             var targetVersions = projectResult.TargetVersions;
+            var sourceVersions = projectResult.SourceVersions;
             var targetVersionMetrics = new List<TargetVersionMetric>();
-            foreach (var targetVersion in targetVersions)
+            for (int i = 0; i < targetVersions.Count; i++)
             {
-                targetVersionMetrics.Add(new TargetVersionMetric(context, targetVersion, projectFile));
+                targetVersionMetrics.Add(new TargetVersionMetric(context, targetVersions[i], projectFile, sourceVersions[i]??null));
             }
 
             return targetVersionMetrics;

--- a/src/CTA.Rules.Metrics/Models/TargetVersionMetric.cs
+++ b/src/CTA.Rules.Metrics/Models/TargetVersionMetric.cs
@@ -11,15 +11,19 @@ namespace CTA.Rules.Metrics
         [JsonProperty("targetVersion", Order = 11)]
         public string TargetVersion { get; set; }
 
+        [JsonProperty("sourceVersion", Order = 12)]
+        public string SourceVersion { get; set; }
+
         [JsonProperty("solutionPath", Order = 30)]
         public string SolutionPathHash { get; set; }
 
         [JsonProperty("projectGuid", Order = 40)]
         public string ProjectGuid { get; set; }
 
-        public TargetVersionMetric(MetricsContext context, string targetVersion, string projectPath)
+        public TargetVersionMetric(MetricsContext context, string targetVersion, string projectPath, string sourceVersion)
         {
             TargetVersion = targetVersion;
+            SourceVersion = sourceVersion;
             SolutionPathHash = context.SolutionPathHash;
             ProjectGuid = context.ProjectGuidMap.GetValueOrDefault(projectPath, "N/A");
         }

--- a/src/CTA.Rules.Models/ProjectConfiguration.cs
+++ b/src/CTA.Rules.Models/ProjectConfiguration.cs
@@ -9,11 +9,13 @@ namespace CTA.Rules.Models
         public ProjectConfiguration()
         {
             TargetVersions = new List<string> { Constants.DefaultCoreVersion };
+            SourceVersions = new List<string> { Constants.DefaultNetFrameworkVersion };
             PackageReferences = new Dictionary<string, Tuple<string, string>>();
             AdditionalReferences = new List<string>();
         }
         public string SolutionPath;
         public string ProjectPath;
+        public List<string> SourceVersions;
         public List<string> TargetVersions;
         public string AssemblyDir;
         public string RulesDir;

--- a/src/CTA.Rules.Models/ProjectResult.cs
+++ b/src/CTA.Rules.Models/ProjectResult.cs
@@ -9,6 +9,7 @@ namespace CTA.Rules.Models
         public List<PackageAction> UpgradePackages { get; set; }
         public List<PackageAction> ActionPackages { get; set; }
         public List<string> TargetVersions { get; set; }
+        public List<string> SourceVersions { get; set; }
         public List<string> MetaReferences { get; set; }
         public List<string> MissingMetaReferences { get; set; }
         public List<WebFormsMetricResult> WebFormsMetricResults { get; set; }
@@ -38,6 +39,13 @@ namespace CTA.Rules.Models
                 stringBuilder.AppendLine(version);
             }
 
+            stringBuilder.AppendLine("---------------------------");
+            stringBuilder.AppendLine("Source Versions:");
+            stringBuilder.AppendLine("---------------------------");
+            foreach (var version in SourceVersions)
+            {
+                stringBuilder.AppendLine(version);
+            }
 
             stringBuilder.AppendLine("---------------------------");
             stringBuilder.AppendLine("Upgrade packages:");

--- a/src/CTA.Rules.PortCore/Program.cs
+++ b/src/CTA.Rules.PortCore/Program.cs
@@ -58,7 +58,8 @@ namespace CTA.Rules.PortCore
                         PackageReferences = packageReferences,
                         PortCode = true,
                         PortProject = true,
-                        TargetVersions = new List<string> { cli.Version }
+                        TargetVersions = new List<string> { cli.Version },
+                        SourceVersions = new List<string> { Constants.DefaultNetFrameworkVersion }
                     };
 
                     configs.Add(projectConfiguration);

--- a/src/CTA.Rules.ProjectFile/ProjectFileCreator.cs
+++ b/src/CTA.Rules.ProjectFile/ProjectFileCreator.cs
@@ -12,6 +12,7 @@ namespace CTA.Rules.ProjectFile
     {
         private readonly string _projectFile;
         private readonly List<string> _targetVersions;
+        private readonly List<string> _sourceVersions;
         private readonly List<string> _metaReferences;
         private Dictionary<string, string> _packages;
         private IEnumerable<string> _projectReferences;
@@ -82,6 +83,27 @@ namespace CTA.Rules.ProjectFile
             List<string> projectReferences, ProjectType projectType, List<string> metaReferences)
         {
             _projectFile = projectFile;
+            _targetVersions = targetVersions;
+            _packages = packages;
+            _projectReferences = projectReferences;
+            _projectType = projectType;
+            _metaReferences = metaReferences;
+
+            try
+            {
+                _projectFileXml = XDocument.Load(projectFile);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogError(ex, "Error initializing project file");
+                throw;
+            }
+        }
+
+        public ProjectFileCreator(string projectFile, List<string> targetVersions, Dictionary<string, string> packages,
+            List<string> projectReferences, ProjectType projectType, List<string> metaReferences, List<string> sourceVersions)
+        {
+            _sourceVersions = sourceVersions; _projectFile = projectFile;
             _targetVersions = targetVersions;
             _packages = packages;
             _projectReferences = projectReferences;

--- a/src/CTA.Rules.ProjectFile/ProjectFileCreator.cs
+++ b/src/CTA.Rules.ProjectFile/ProjectFileCreator.cs
@@ -101,24 +101,9 @@ namespace CTA.Rules.ProjectFile
         }
 
         public ProjectFileCreator(string projectFile, List<string> targetVersions, Dictionary<string, string> packages,
-            List<string> projectReferences, ProjectType projectType, List<string> metaReferences, List<string> sourceVersions)
+            List<string> projectReferences, ProjectType projectType, List<string> metaReferences, List<string> sourceVersions) : this(projectFile, targetVersions, packages, projectReferences, projectType, metaReferences)
         {
-            _sourceVersions = sourceVersions; _projectFile = projectFile;
-            _targetVersions = targetVersions;
-            _packages = packages;
-            _projectReferences = projectReferences;
-            _projectType = projectType;
-            _metaReferences = metaReferences;
-
-            try
-            {
-                _projectFileXml = XDocument.Load(projectFile);
-            }
-            catch (Exception ex)
-            {
-                LogHelper.LogError(ex, "Error initializing project file");
-                throw;
-            }
+            _sourceVersions = sourceVersions;
         }
 
         private string GetTargetVersions()

--- a/src/CTA.Rules.Update/Program.cs
+++ b/src/CTA.Rules.Update/Program.cs
@@ -36,7 +36,8 @@ namespace CTA.Rules.Update
                         ProjectPath = proj,
                         RulesDir = cli.RulesDir,
                         IsMockRun = cli.IsMockRun,
-                        TargetVersions = new List<string> { "net5.0" }
+                        TargetVersions = new List<string> { "net5.0" },
+                        SourceVersions = new List<string> { Constants.DefaultNetFrameworkVersion }
                     };
 
                     configs.Add(projectConfiguration);

--- a/src/CTA.Rules.Update/ProjectRewriters/ProjectRewriter.cs
+++ b/src/CTA.Rules.Update/ProjectRewriters/ProjectRewriter.cs
@@ -36,6 +36,7 @@ namespace CTA.Rules.Update
             {
                 ProjectFile = projectConfiguration.ProjectPath,
                 TargetVersions = projectConfiguration.TargetVersions,
+                SourceVersions = projectConfiguration.SourceVersions,
                 UpgradePackages = projectConfiguration.PackageReferences.Select(p => new PackageAction()
                 {
                     Name = p.Key,
@@ -64,6 +65,7 @@ namespace CTA.Rules.Update
             {
                 ProjectFile = projectConfiguration.ProjectPath,
                 TargetVersions = projectConfiguration.TargetVersions,
+                SourceVersions = projectConfiguration.SourceVersions,
                 UpgradePackages = projectConfiguration.PackageReferences.Select(p => new PackageAction()
                 {
                     Name = p.Key,

--- a/src/CTA.Rules.sln
+++ b/src/CTA.Rules.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30309.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CTA.Rules.Actions", "CTA.Rules.Actions\CTA.Rules.Actions.csproj", "{F44D3F33-6CF3-4A81-B213-0A34773D6A80}"
 EndProject

--- a/tst/CTA.Rules.Test/Metrics/PortSolutionResultReportGeneratorTests.cs
+++ b/tst/CTA.Rules.Test/Metrics/PortSolutionResultReportGeneratorTests.cs
@@ -324,6 +324,10 @@ Target Versions:
 ---------------------------
 netcoreapp3.1
 ---------------------------
+Source Versions:
+---------------------------
+net48
+---------------------------
 Upgrade packages:
 ---------------------------
 Newtonsoft.Json,9.0.0->12.0.0
@@ -401,6 +405,7 @@ Count: 400";
     ""metricsType"": ""CTA"",
     ""metricName"": ""TargetVersion"",
     ""targetVersion"": ""netcoreapp3.1"",
+    ""sourceVersion"": ""net48"",
     ""solutionPath"": ""5fa9de0cb5af2d468dfb1702b1e342f47de2df9a195dabb3be2d04f9c2767482"",
     ""projectGuid"": ""1234-5678""
   },

--- a/tst/CTA.Rules.Test/Metrics/PortSolutionResultReportGeneratorTests.cs
+++ b/tst/CTA.Rules.Test/Metrics/PortSolutionResultReportGeneratorTests.cs
@@ -79,6 +79,7 @@ namespace CTA.Rules.Test.Metrics
                 {
                     ProjectFile = projectPath1,
                     TargetVersions = new List<string>() {Constants.DefaultCoreVersion},
+                    SourceVersions = new List<string> {Constants.DefaultNetFrameworkVersion},
                     UpgradePackages = new List<PackageAction>() {new PackageAction() { Name = "Newtonsoft.Json", OriginalVersion="9.0.0", Version="12.0.0" } },
                     MissingMetaReferences = new List<string> { @"C://reference1.dll", @"C://reference2.dll" },
                     ProjectActions = new ProjectActions() {

--- a/tst/CTA.Rules.Test/ProjectFileCreatorTests.cs
+++ b/tst/CTA.Rules.Test/ProjectFileCreatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using CTA.Rules.Config;
 using CTA.Rules.Models;
 using CTA.Rules.ProjectFile;
 using NUnit.Framework;
@@ -23,7 +24,8 @@ namespace CTA.Rules.Test
             CreateEmptyXmlDocument(_classLibraryProjectFilePath);
             CreateEmptyXmlDocument(_webClassLibraryProjectFilePath);
 
-            var targetFramework = new List<string> { "netcoreapp3.1" };
+            var targetFramework = new List<string> { Constants.DefaultCoreVersion };
+            var sourceFramework = new List<string> { Constants.DefaultNetFrameworkVersion };
             var packages = new Dictionary<string, string>
             {
                 { "MyFirstPackage", "1.0.0" },
@@ -40,11 +42,11 @@ namespace CTA.Rules.Test
             };
 
             _mvcProjectFileCreator = new ProjectFileCreator(_mvcProjectFilePath, targetFramework, 
-                packages, projectReferences, ProjectType.Mvc, metaRefs);
+                packages, projectReferences, ProjectType.Mvc, metaRefs, sourceFramework);
             _classLibraryProjectFileCreator = new ProjectFileCreator(_classLibraryProjectFilePath, targetFramework, 
-                packages, projectReferences, ProjectType.ClassLibrary, metaRefs);
+                packages, projectReferences, ProjectType.ClassLibrary, metaRefs, sourceFramework);
             _webClassLibraryProjectFileCreator = new ProjectFileCreator(_webClassLibraryProjectFilePath, targetFramework, 
-                packages, projectReferences, ProjectType.WebClassLibrary, metaRefs);
+                packages, projectReferences, ProjectType.WebClassLibrary, metaRefs, sourceFramework);
         }
 
         [TearDown]


### PR DESCRIPTION
## Related issue

Closes: #639 

## Description
Currently CTA is passed source version from PA but loses track of it within its models.

## Supplemental testing
Pass all unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
