### PR TITLE
Add bouncycastle tests

### DIFF
--- a/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
+++ b/tst/CTA.Rules.Test/CTA.Rules.Test.csproj
@@ -42,6 +42,12 @@
     <None Update="CTAFiles\action.namespace.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TempRules\project.all.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TempTemplates\webforms\appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
 	<None Update="TestFiles\Configs\Web.config">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</None>


### PR DESCRIPTION
## Description
* Add tests to confirm BouncyCastle rules defined in https://github.com/aws/porting-assistant-dotnet-datastore/pull/143


## Additional context
* These tests were run locally by using the rules defined in https://github.com/aws/porting-assistant-dotnet-datastore/pull/143 and adding them to the CTA TempRules directory. The temp rules were excluded from this PR.
* Unit tests will fail until https://github.com/aws/porting-assistant-dotnet-datastore/pull/143 is merged.