### PR TITLE
Support remove using directive actions inside namespace block

### DIFF
--- a/src/CTA.Rules.Actions/NamespaceActions.cs
+++ b/src/CTA.Rules.Actions/NamespaceActions.cs
@@ -19,21 +19,12 @@ namespace CTA.Rules.Actions
             return RenameNamespace;
         }
 
-        public Func<SyntaxGenerator, NamespaceDeclarationSyntax, NamespaceDeclarationSyntax> GetAddDirectiveAction(string @namespace)
-        {
-            NamespaceDeclarationSyntax AddDirective(SyntaxGenerator syntaxGenerator, NamespaceDeclarationSyntax node)
-            {
-                var allUsings = node.Usings;
-
-                var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(@namespace)).NormalizeWhitespace();
-                allUsings = allUsings.Add(usingDirective);
-
-                node = node.WithUsings(allUsings).NormalizeWhitespace();
-                return node;
-            }
-            return AddDirective;
-        }
-
+        /// <summary>
+        /// Only support remove using directive actions inside Namespace block.
+        /// The add using directive actions will be happening in CompiliationUnit.
+        /// </summary>
+        /// <param name="namespace"></param>
+        /// <returns></returns>
         public Func<SyntaxGenerator, NamespaceDeclarationSyntax, NamespaceDeclarationSyntax> GetRemoveDirectiveAction(string @namespace)
         {
             NamespaceDeclarationSyntax RemoveDirective(SyntaxGenerator syntaxGenerator, NamespaceDeclarationSyntax node)

--- a/src/CTA.Rules.Analysis/RulesAnalysis.cs
+++ b/src/CTA.Rules.Analysis/RulesAnalysis.cs
@@ -498,7 +498,8 @@ namespace CTA.Rules.Analyzer
                 Type = a.Type,
                 TextSpan = textSpan,
                 ActionValidation = a.ActionValidation,
-                UsingActionFunc = a.UsingActionFunc
+                UsingActionFunc = a.UsingActionFunc,
+                NamespaceUsingActionFunc = a.NamespaceUsingActionFunc,
             }).ToList());
 
             fileAction.NamespaceActions.UnionWith(token.NamespaceActions.Select(a => new NamespaceAction()

--- a/src/CTA.Rules.Models/Actions/Usingaction.cs
+++ b/src/CTA.Rules.Models/Actions/Usingaction.cs
@@ -8,12 +8,17 @@ namespace CTA.Rules.Models
     public class UsingAction : GenericAction
     {
         public Func<SyntaxGenerator, CompilationUnitSyntax, CompilationUnitSyntax> UsingActionFunc { get; set; }
+        public Func<SyntaxGenerator, NamespaceDeclarationSyntax, NamespaceDeclarationSyntax> NamespaceUsingActionFunc { get; set; }
 
         public override bool Equals(object obj)
         {
             var action = (UsingAction)obj;
             return action?.Value == this.Value
-                && action?.UsingActionFunc.Method.Name == this.UsingActionFunc.Method.Name;
+                    &&  (
+                            (action?.UsingActionFunc.Method.Name == this.UsingActionFunc.Method.Name)
+                            ||
+                            (action?.NamespaceUsingActionFunc.Method.Name == this.NamespaceUsingActionFunc.Method.Name)
+                        );
         }
 
         public override int GetHashCode()

--- a/src/CTA.Rules.RuleFiles/RulesFileParser.cs
+++ b/src/CTA.Rules.RuleFiles/RulesFileParser.cs
@@ -458,9 +458,9 @@ namespace CTA.Rules.RuleFiles
                         case ActionTypes.Using:
                             {
                                 var actionFunc = actionsLoader.GetCompilationUnitAction(action.Name, action.Value);
-                                // Using directives can be found in both Complilation Unit and inside Namespace.
-                                // Need to take care of it for both possible occurrences.
-                                // The Cons of this approach would result with multiple add operations but harmless.
+                                // Using directives can be found in both ComplilationUnit and inside Namespace.
+                                // Need to make sure remove action is taken if it's inside Namespace block.
+                                // Only add using directives in the CompilationUnit as our convention, so it's not added twice.
                                 var namespaceActionFunc = actionsLoader.GetNamespaceActions(action.Name, action.Value);
                                 if (actionFunc != null)
                                 {

--- a/src/CTA.Rules.RuleFiles/RulesFileParser.cs
+++ b/src/CTA.Rules.RuleFiles/RulesFileParser.cs
@@ -458,6 +458,10 @@ namespace CTA.Rules.RuleFiles
                         case ActionTypes.Using:
                             {
                                 var actionFunc = actionsLoader.GetCompilationUnitAction(action.Name, action.Value);
+                                // Using directives can be found in both Complilation Unit and inside Namespace.
+                                // Need to take care of it for both possible occurrences.
+                                // The Cons of this approach would result with multiple add operations but harmless.
+                                var namespaceActionFunc = actionsLoader.GetNamespaceActions(action.Name, action.Value);
                                 if (actionFunc != null)
                                 {
                                     nodeToken.UsingActions.Add(new UsingAction()
@@ -468,7 +472,8 @@ namespace CTA.Rules.RuleFiles
                                         ActionValidation = action.ActionValidation,
                                         Name = action.Name,
                                         Type = action.Type,
-                                        UsingActionFunc = actionFunc
+                                        UsingActionFunc = actionFunc,
+                                        NamespaceUsingActionFunc = namespaceActionFunc
                                     });
                                 }
                                 break;

--- a/src/CTA.Rules.Update/ActionsRewriter.cs
+++ b/src/CTA.Rules.Update/ActionsRewriter.cs
@@ -378,7 +378,7 @@ namespace CTA.Rules.Update.Rewriters
                 try
                 {
                     newNode = action.UsingActionFunc(_syntaxGenerator, newNode);
-                    LogHelper.LogInformation(string.Format("{0}", action.Description));
+                    LogHelper.LogInformation(string.Format("{0} in CompilationUnit.", action.Description));
                 }
                 catch (Exception ex)
                 {
@@ -451,9 +451,14 @@ namespace CTA.Rules.Update.Rewriters
                     allExecutedActions.Add(actionExecution);
                 }
             }
-            // Handle namespace add or remove using actions.
+            // Handle namespace remove using actions.
             foreach (var action in _allActions.OfType<UsingAction>())
             {
+                if (action.NamespaceUsingActionFunc == null)
+                {
+                    continue;
+                }
+
                 var actionExecution = new GenericActionExecution(action, _filePath)
                 {
                     TimesRun = 1
@@ -461,7 +466,7 @@ namespace CTA.Rules.Update.Rewriters
                 try
                 {
                     newNode = action.NamespaceUsingActionFunc(_syntaxGenerator, newNode);
-                    LogHelper.LogInformation(string.Format("{0}", action.Description));
+                    LogHelper.LogInformation(string.Format("{0} in Namespace block.", action.Description));
                 }
                 catch (Exception ex)
                 {

--- a/tst/CTA.Rules.Test/Actions/ActionsLoaderTests.cs
+++ b/tst/CTA.Rules.Test/Actions/ActionsLoaderTests.cs
@@ -214,8 +214,10 @@ namespace CTA.Rules.Test.Actions
         public void NamespaceActionsTest()
         {
             var renameNamespace = _actionLoader.GetNamespaceActions("RenameNamespace", "newName");
+            var removeUsingDirective = _actionLoader.GetNamespaceActions("RemoveDirective", "newNamespace");
 
             Assert.IsNotNull(renameNamespace);
+            Assert.IsNotNull(removeUsingDirective);
         }
 
         [Test]

--- a/tst/CTA.Rules.Test/Actions/NamespaceActionsTests.cs
+++ b/tst/CTA.Rules.Test/Actions/NamespaceActionsTests.cs
@@ -1,0 +1,79 @@
+﻿using CTA.FeatureDetection.Common.Extensions;
+using CTA.Rules.Actions;
+using CTA.Rules.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using NUnit.Framework;
+using System.Linq;
+
+namespace CTA.Rules.Test.Actions
+{
+    internal class NamespaceActionsTests
+    {
+        private SyntaxGenerator _syntaxGenerator;
+        private NamespaceActions _namespaceActions;
+        private NamespaceDeclarationSyntax _node;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var workspace = new AdhocWorkspace();
+            var language = LanguageNames.CSharp;
+            _syntaxGenerator = SyntaxGenerator.GetGenerator(workspace, language);
+            _namespaceActions = new NamespaceActions();
+
+            SyntaxTree tree = CSharpSyntaxTree.ParseText(
+                @$"
+                namespace DummyNamespace
+                {{
+                    using System.Web;
+                    class MyClass
+                    {{
+                    }};
+                }}");
+            _node = tree.GetRoot()
+                        .DescendantNodes()
+                        .OfType<NamespaceDeclarationSyntax>()
+                        .FirstOrDefault();
+        }
+
+        [Test]
+        public void GetRenameNamespaceAction_Rename_Namespace()
+        {
+            const string newNamespaceName = "NewNamespace";
+            var renameNamespaceFunc = _namespaceActions.GetRenameNamespaceAction(newNamespaceName);
+            var newNode = renameNamespaceFunc(_syntaxGenerator, _node);
+
+            var expectedResult = CSharpSyntaxTree.ParseText(@$"
+                    namespace NewNamespace
+                    {{
+                        using System.Web;
+                        class MyClass
+                        {{
+                        }};
+                    }}").GetRoot();
+            Assert.AreEqual(expectedResult.RemoveAllTrivia().ToFullString(), newNode.RemoveAllTrivia().ToFullString());
+        }
+
+        [Test]
+        public void GetRemoveDirectiveAction_Removes_Directive()
+        {
+            const string directive = "System.Web";
+            var removeDirectiveFunc = _namespaceActions.GetRemoveDirectiveAction(directive);
+            var newNode = removeDirectiveFunc(_syntaxGenerator, _node);
+
+            var expectedResult = CSharpSyntaxTree.ParseText(@$"
+                    namespace DummyNamespace
+                    {{
+                        class MyClass
+                        {{
+                        }};
+                    }}").GetRoot();
+            Assert.AreEqual(expectedResult.RemoveAllTrivia().ToFullString(), newNode.RemoveAllTrivia().ToFullString());
+        }
+
+
+    }
+}

--- a/tst/CTA.Rules.Test/PortCoreTests.cs
+++ b/tst/CTA.Rules.Test/PortCoreTests.cs
@@ -472,11 +472,24 @@ namespace CTA.Rules.Test
         [TestCase(TargetFramework.DotnetCoreApp31)]
         public void TestBuildableWebApiSolution(string version)
         {
-            TestSolutionAnalysis resultWithoutCodePort = AnalyzeSolution("BuildableWebApi.sln", tempDir, downloadLocation, version, portCode: false);
-            var buildErrorsWithoutPortCode = GetSolutionBuildErrors(resultWithoutCodePort.SolutionRunResult.SolutionPath);
-            Assert.AreEqual(35, buildErrorsWithoutPortCode.Count);
+            TestSolutionAnalysis resultWithoutCodePort = AnalyzeSolution(
+                "BuildableWebApi.sln",
+                tempDir,
+                downloadLocation,
+                version,
+                portCode: false);
 
-            TestSolutionAnalysis results = AnalyzeSolution("BuildableWebApi.sln", tempDir, downloadLocation, version);
+            var buildErrorsWithoutPortCode = GetSolutionBuildErrors(resultWithoutCodePort.SolutionRunResult.SolutionPath);
+            // Build errors were added by 3 because of the PR here:
+            // https://github.com/marknfawaz/TestProjects/pull/71
+            Assert.AreEqual(38, buildErrorsWithoutPortCode.Count);
+
+            TestSolutionAnalysis results = AnalyzeSolution(
+                "BuildableWebApi.sln",
+                tempDir,
+                downloadLocation,
+                version);
+
             var buildErrors = GetSolutionBuildErrors(results.SolutionRunResult.SolutionPath);
             Assert.AreEqual(0, buildErrors.Count);
         }


### PR DESCRIPTION
## Related issue
Some developers choose to write using directives inside the namespace block, and we are not applying our remove actions for those situations.

Closes: #ISSUE_NUMBER_HERE


## Description
* We need to handle removing using directive actions in both CompilationUnit and inside Namespace. 
* Regarding add using directives, we are only adding them inside CompilationUnit as our convention. 

## Supplemental testing
Added unit tests to cover the changes in this PR.
Adjusted the build error count based on below changes by updating our BuidableWebApi project at https://github.com/marknfawaz/TestProjects for the test case:
`namespace BuildableWebApi.Controllers
{
    using System.Web.Http;
    using System.Web.Http.OData;
}`
And this project is covered in our test cases.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
