### PR TITLE
Add CastExpressionSyntax into Identifier types

### DIFF
--- a/src/CTA.Rules.Update/ActionsRewriter.cs
+++ b/src/CTA.Rules.Update/ActionsRewriter.cs
@@ -31,7 +31,9 @@ namespace CTA.Rules.Update.Rewriters
             typeof(TypeParameterListSyntax),
             typeof(ParameterSyntax),
             typeof(ObjectCreationExpressionSyntax),
-            typeof(QualifiedNameSyntax)};
+            typeof(QualifiedNameSyntax),
+            typeof(CastExpressionSyntax),
+        };
 
         public ActionsRewriter(SemanticModel semanticModel, SemanticModel preportSemanticModel, SyntaxGenerator syntaxGenerator, string filePath, List<GenericAction> allActions)
         {


### PR DESCRIPTION
## Related issue
When porting code, we want to replace an identifier but failed to do so because it's of CastExpressionSyntax.

Closes: #ISSUE_NUMBER_HERE


## Description
* Added CastExpressionSyntax into identifier types so it is included in the replace actions if needed.

## Supplemental testing
The test case is added into BuildableWebApi project at https://github.com/marknfawaz/TestProjects
'return (IHttpActionResult)Ok();'
And this project is covered in our test cases.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
