### PR TITLE
Webforms reference linker cancellation fix

### DIFF
--- a/src/CTA.WebForms/ClassConverters/ControlCodeBehindClassConverter.cs
+++ b/src/CTA.WebForms/ClassConverters/ControlCodeBehindClassConverter.cs
@@ -35,6 +35,9 @@ namespace CTA.WebForms.ClassConverters
         {
             _codeBehindLinkerService = codeBehindLinkerService;
             _metricsContext = metricsContext;
+            // Need to register the code behind at converter creation, before migration logic in
+            // view converters need that information
+            _codeBehindLinkerService.RegisterCodeBehindFile(Path.ChangeExtension(FullPath, null));
         }
 
         public override async Task<IEnumerable<FileInformation>> MigrateClassAsync()

--- a/src/CTA.WebForms/ClassConverters/MasterPageCodeBehindClassConverter.cs
+++ b/src/CTA.WebForms/ClassConverters/MasterPageCodeBehindClassConverter.cs
@@ -36,6 +36,9 @@ namespace CTA.WebForms.ClassConverters
         {
             _codeBehindLinkerService = codeBehindLinkerService;
             _metricsContext = metricsContext;
+            // Need to register the code behind at converter creation, before migration logic in
+            // view converters need that information
+            _codeBehindLinkerService.RegisterCodeBehindFile(Path.ChangeExtension(FullPath, null));
         }
 
         public override async Task<IEnumerable<FileInformation>> MigrateClassAsync()

--- a/src/CTA.WebForms/ClassConverters/PageCodeBehindClassConverter.cs
+++ b/src/CTA.WebForms/ClassConverters/PageCodeBehindClassConverter.cs
@@ -38,6 +38,10 @@ namespace CTA.WebForms.ClassConverters
             _newLifecycleLines = new Dictionary<BlazorComponentLifecycleEvent, IEnumerable<StatementSyntax>>();
             _codeBehindLinkerService = codeBehindLinkerService;
             _metricsContext = metricsContext;
+
+            // Need to register the code behind at converter creation, before migration logic in
+            // view converters need that information
+            _codeBehindLinkerService.RegisterCodeBehindFile(Path.ChangeExtension(FullPath, null));
         }
 
         public override async Task<IEnumerable<FileInformation>> MigrateClassAsync()

--- a/src/CTA.WebForms/Helpers/TagConversion/TagCodeBehindLink.cs
+++ b/src/CTA.WebForms/Helpers/TagConversion/TagCodeBehindLink.cs
@@ -13,6 +13,8 @@ namespace CTA.WebForms.Helpers.TagConversion
         public List<TagCodeBehindHandler> Handlers { get; }
         public SemanticModel SemanticModel { get; set; }
         public ClassDeclarationSyntax ClassDeclaration { get; set; }
+        public bool CodeBehindFileExists { get; set; }
+        public bool ViewFileExists { get; set; }
 
         public TagCodeBehindLink()
         {

--- a/tst/CTA.WebForms.Tests/Services/CodeBehindReferenceLinkerServiceTests.cs
+++ b/tst/CTA.WebForms.Tests/Services/CodeBehindReferenceLinkerServiceTests.cs
@@ -50,6 +50,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterClassDeclaration(testPath, model, classDec);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             var result = await _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
@@ -84,6 +85,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterClassDeclaration(testPath, model, classDec);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             var result = await _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, null, testHandler, token);
@@ -118,6 +120,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterClassDeclaration(testPath, model, classDec);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             var result1 = await _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, null, testHandler, token);
@@ -150,11 +153,33 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterClassDeclaration(testPath, model, classDec);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             var result = await _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
 
             Assert.IsNull(result);
+        }
+
+        [Test]
+        public async Task HandleCodeBehindForAttribute_Returns_Null_If_No_Code_Behind_File_Registered()
+        {
+            var testPath = Path.Combine("C:", "Something", "File.aspx");
+            var testHandler = new DefaultTagCodeBehindHandler(
+                "System.Web.UI.WebControls.Button",
+                "MyButton");
+            var token = new CancellationTokenSource().Token;
+
+            _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindHandler(testPath, testHandler);
+
+            var resultTask = _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
+
+            // Give the task time to complete
+            await Task.Delay(200);
+
+            Assert.True(resultTask.IsCompletedSuccessfully);
+            Assert.IsNull(resultTask.Result);
         }
 
         [Test]
@@ -168,9 +193,9 @@ namespace Test {
             var token = tokenSource.Token;
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             
-
             Assert.ThrowsAsync(typeof(TaskCanceledException), async () =>
             {
                 var task = _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
@@ -206,6 +231,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterClassDeclaration(testPath, model, classDec);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
 
@@ -244,12 +270,21 @@ namespace Test {
         }
 
         [Test]
-        public void RegisterViewFile_Throws_Invalid_Operation_Exception_On_Double_Registration()
+        public void RegisterViewFile_Successfully_Registers_When_Called_Before_RegisterCodeBehindFile()
         {
             var testPath = Path.Combine("C:", "Something", "File.aspx");
-            _service.RegisterViewFile(testPath);
 
-            Assert.Throws(typeof(InvalidOperationException), () => _service.RegisterViewFile(testPath));
+            Assert.DoesNotThrow(() => _service.RegisterViewFile(testPath));
+            Assert.DoesNotThrow(() => _service.RegisterCodeBehindFile(testPath));
+        }
+
+        [Test]
+        public void RegisterCodeBehindFile_Successfully_Registers_When_Called_Before_RegisterViewFile()
+        {
+            var testPath = Path.Combine("C:", "Something", "File.aspx");
+
+            Assert.DoesNotThrow(() => _service.RegisterCodeBehindFile(testPath));
+            Assert.DoesNotThrow(() => _service.RegisterViewFile(testPath));
         }
 
         [Test]
@@ -279,6 +314,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
 
             var result = _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
@@ -320,7 +356,9 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterViewFile(otherPath);
+            _service.RegisterCodeBehindFile(otherPath);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
 
             var result = _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
@@ -396,6 +434,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var _));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
 
             Assert.Throws(typeof(ArgumentNullException), () => _service.RegisterClassDeclaration(testPath, null, classDec));
         }
@@ -427,6 +466,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var _, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
 
             Assert.Throws(typeof(ArgumentNullException), () => _service.RegisterClassDeclaration(testPath, model, null));
         }
@@ -458,6 +498,8 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
+
             var resultTask = _service.ExecuteTagCodeBehindHandlersAsync(testPath, model, classDec, token);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             await _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
@@ -509,6 +551,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             var resultTask = _service.ExecuteTagCodeBehindHandlersAsync(testPath, model, classDec, token);
             await _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
@@ -563,6 +606,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
 
             _service.RegisterCodeBehindHandler(testPath, buttonHandler);
             _service.RegisterCodeBehindHandler(testPath, otherButtonHandler);
@@ -614,6 +658,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             var resultTask = _service.ExecuteTagCodeBehindHandlersAsync(testPath, model, classDec, token);
             await _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);
@@ -682,6 +727,7 @@ namespace Test {
             Assert.True(CreateSimpleCodeBehindCompilation(inputClass, out var classDec, out var model));
 
             _service.RegisterViewFile(testPath);
+            _service.RegisterCodeBehindFile(testPath);
             _service.RegisterCodeBehindHandler(testPath, testHandler);
             var resultTask = _service.ExecuteTagCodeBehindHandlersAsync(testPath, model, classDec, token);
             await _service.HandleCodeBehindForAttributeAsync(testPath, "Text", null, "NewTextValue", testHandler, token);


### PR DESCRIPTION
## Description
* Added registration for code behind classes
* Altered code behind reference linking to do nothing if either the view or code behind file was not registered
* Updated code behind class converters to use new registration methods

* Added new unit tests to verify new code behind registration check works
* Updated existing unit tests to use new code behind registration code

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
