### PR TITLE
reload syntax tree for source file which already applied code change

### DIFF
--- a/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
+++ b/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
@@ -46,16 +46,21 @@ namespace CTA.WebForms.FileConverters
             {
                 var sourcefileBuildResult = _webFormsProjectAnaylzer.AnalyzerResult.ProjectBuildResult?.SourceFileBuildResults?
                     .Single(r => r.SourceFileFullPath.Equals(fullPath, StringComparison.OrdinalIgnoreCase));
+                
                 var oldFileModel = sourcefileBuildResult?.SemanticModel;
                 var oldTree = sourcefileBuildResult?.SyntaxTree;
                 SyntaxTree newTree;
                 if (fullPath.EndsWith(".cs"))
                 {
-                    newTree = CSharpSyntaxTree.ParseText(File.ReadAllText(fullPath));
+                    var languageVersion = ((Microsoft.CodeAnalysis.CSharp.CSharpParseOptions)(sourcefileBuildResult?.SemanticModel?.SyntaxTree?.Options)).LanguageVersion;
+                    var options = CSharpParseOptions.Default.WithLanguageVersion(languageVersion);
+                    newTree = CSharpSyntaxTree.ParseText(File.ReadAllText(fullPath), options);
                 }
                 else if (fullPath.EndsWith(".vb"))
                 {
-                    newTree = VisualBasicSyntaxTree.ParseText(File.ReadAllText(fullPath));
+                    var vblanguageVersion = ((Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions)(sourcefileBuildResult?.SemanticModel?.SyntaxTree?.Options)).LanguageVersion;
+                    var options = VisualBasicParseOptions.Default.WithLanguageVersion(vblanguageVersion);
+                    newTree = VisualBasicSyntaxTree.ParseText(File.ReadAllText(fullPath), options);
                 }
                 else
                 {

--- a/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
+++ b/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
@@ -23,7 +23,7 @@ namespace CTA.WebForms.FileConverters
     {
         private const string ChildActionType = "CodeFileConverter";
         private readonly SemanticModel _fileModel;
-        private readonly SemanticModel _orignalModel;
+        private readonly SemanticModel _orignialModel;
         private readonly WorkspaceManagerService _blazorWorkspaceBuilder;
         private readonly ProjectAnalyzer _webFormsProjectAnaylzer;
         private readonly ClassConverterFactory _classConverterFactory;
@@ -44,19 +44,19 @@ namespace CTA.WebForms.FileConverters
             _webFormsProjectAnaylzer = webFormsProjectAnalyzer;
             _classConverterFactory = classConverterFactory;
             _metricsContext = metricsContext;
-            Dictionary<string, string> symbolClassConverterDic = new Dictionary<string, string>();
+            var symbolClassConverterDic = new Dictionary<string, string>();
             try
             {
 
                 var sourcefileBuildResult = _webFormsProjectAnaylzer.AnalyzerResult.ProjectBuildResult?.SourceFileBuildResults?
                     .Single(r => r.SourceFileFullPath.Equals(fullPath, StringComparison.OrdinalIgnoreCase));
 
-                _orignalModel = sourcefileBuildResult?.SemanticModel;
+                _orignialModel = sourcefileBuildResult?.SemanticModel;
                 var sourceFileRelativePath = sourcefileBuildResult?.SourceFileFullPath;
-                var namespaceLevelTypes = _orignalModel?.SyntaxTree?.GetNamespaceLevelTypes();
+                var namespaceLevelTypes = _orignialModel?.SyntaxTree?.GetNamespaceLevelTypes();
                 foreach (var namespaceLevelType in namespaceLevelTypes)
                 {
-                    var symbol = _orignalModel?.GetDeclaredSymbol(namespaceLevelType);
+                    var symbol = _orignialModel?.GetDeclaredSymbol(namespaceLevelType);
 
                     if (symbol.GetAllInheritedBaseTypes().Any(typeSymbol => typeSymbol.Name.Equals(Constants.ExpectedGlobalBaseClass))
                         && sourceFileRelativePath.EndsWith(Constants.ExpectedGlobalFileName, StringComparison.InvariantCultureIgnoreCase))
@@ -95,7 +95,7 @@ namespace CTA.WebForms.FileConverters
                     symbolClassConverterDic.TryAdd(symbol.ToDisplayString(), "UnknownClassConverter");
 
                 }
-                var oldFileModel = sourcefileBuildResult?.SemanticModel;
+
                 var oldTree = sourcefileBuildResult?.SyntaxTree;
                 var oldEncoding = oldTree.Encoding;
                 SyntaxTree newTree = null;
@@ -116,7 +116,7 @@ namespace CTA.WebForms.FileConverters
 
                 if (newTree != null && newTree != oldTree)
                 {
-                    var newCompilation = oldFileModel?.Compilation?.ReplaceSyntaxTree(oldTree, newTree);
+                    var newCompilation = _orignialModel?.Compilation?.ReplaceSyntaxTree(oldTree, newTree);
                     _fileModel = newCompilation?.GetSemanticModel(newTree);
                 }
                 
@@ -133,7 +133,7 @@ namespace CTA.WebForms.FileConverters
             }
 
             
-            if (_orignalModel != null && _fileModel!= null)
+            if (_fileModel!= null)
             {
                 _classConverters = _classConverterFactory.BuildMany(symbolClassConverterDic, RelativePath, _fileModel );
             }

--- a/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
+++ b/src/CTA.WebForms/FileConverters/CodeFileConverter.cs
@@ -49,8 +49,8 @@ namespace CTA.WebForms.FileConverters
                 
                 var oldFileModel = sourcefileBuildResult?.SemanticModel;
                 var oldTree = sourcefileBuildResult?.SyntaxTree;
-                SyntaxTree newTree;
-                if (fullPath.EndsWith(".cs"))
+                SyntaxTree newTree = null;
+                if ( fullPath.EndsWith(".cs"))
                 {
                     var languageVersion = ((Microsoft.CodeAnalysis.CSharp.CSharpParseOptions)(sourcefileBuildResult?.SemanticModel?.SyntaxTree?.Options)).LanguageVersion;
                     var options = CSharpParseOptions.Default.WithLanguageVersion(languageVersion);
@@ -62,11 +62,7 @@ namespace CTA.WebForms.FileConverters
                     var options = VisualBasicParseOptions.Default.WithLanguageVersion(vblanguageVersion);
                     newTree = VisualBasicSyntaxTree.ParseText(File.ReadAllText(fullPath), options);
                 }
-                else
-                {
-                    newTree = null;
-                    LogHelper.LogError($"invalid source code language for {fullPath}");
-                }
+                
 
                 if (newTree != null)
                 {
@@ -74,7 +70,8 @@ namespace CTA.WebForms.FileConverters
                     _fileModel = newCompilation?.GetSemanticModel(newTree);
                 }
                 else {
-                    _fileModel = null;
+                    _fileModel = _webFormsProjectAnaylzer.AnalyzerResult.ProjectBuildResult?.SourceFileBuildResults?
+                   .Single(r => r.SourceFileFullPath.Equals(fullPath, StringComparison.OrdinalIgnoreCase))?.SemanticModel;
                 }
 
             }

--- a/tst/CTA.Rules.Test/Models/ExpectedOutputConstants.cs
+++ b/tst/CTA.Rules.Test/Models/ExpectedOutputConstants.cs
@@ -1672,17 +1672,18 @@ namespace ASP.NET_WebForms
 @"using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
 namespace ASP.NET_WebForms
 {
     public class Startup
     {
+        RequestDelegate _next = null;
         public IConfiguration Configuration { get; }
 
         public IWebHostEnvironment Env { get; }

--- a/tst/CTA.Rules.Test/Models/WebFormsFullExpectedOutputConstants.cs
+++ b/tst/CTA.Rules.Test/Models/WebFormsFullExpectedOutputConstants.cs
@@ -46,9 +46,10 @@ using WebFormsFull.Modules;
 using log4net;
 using System;
 using System.Configuration;
-using System.Data.Entity;
 using System.Diagnostics;
-using System.Web;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace WebFormsFull

--- a/tst/CTA.WebForms.Tests/Factories/ClassConverterFactoryTests.cs
+++ b/tst/CTA.WebForms.Tests/Factories/ClassConverterFactoryTests.cs
@@ -107,7 +107,7 @@ namespace CTA.WebForms.Tests.Factories
             var testDocumentPath = Path.Combine("C:", "Directory1", "Directory2", testFileName);
             var did = _workspaceManager.AddDocument(_primaryProjectId, "TestDocument", testDocumentText);
             var model = await _workspaceManager.GetCurrentDocumentSemanticModel(did);
-            var classConverter = _classConverterFactory.BuildMany(testDocumentPath, model).Single();
+            var classConverter = _classConverterFactory.BuildMany(new Dictionary<string, string>() { { "TestNamespace.TestPage" , "PageCodeBehindClassConverter" } }, testDocumentPath, model).Single();
 
             Assert.IsInstanceOf(targetType, classConverter);
         }
@@ -120,7 +120,7 @@ namespace CTA.WebForms.Tests.Factories
             var testDocumentPath = Path.Combine("C:", "Directory1", "Directory2", "TestDocumentName.cs");
             var did = _workspaceManager.AddDocument(_primaryProjectId, "TestDocument", DocumentMultiClassText);
             var model = await _workspaceManager.GetCurrentDocumentSemanticModel(did);
-            var classConverters = _classConverterFactory.BuildMany(testDocumentPath, model);
+            var classConverters = _classConverterFactory.BuildMany(new Dictionary<string, string>(), testDocumentPath, model);
 
             Assert.AreEqual(4, classConverters.Count());
         }

--- a/tst/CTA.WebForms.Tests/Factories/ClassConverterFactoryTests.cs
+++ b/tst/CTA.WebForms.Tests/Factories/ClassConverterFactoryTests.cs
@@ -107,7 +107,15 @@ namespace CTA.WebForms.Tests.Factories
             var testDocumentPath = Path.Combine("C:", "Directory1", "Directory2", testFileName);
             var did = _workspaceManager.AddDocument(_primaryProjectId, "TestDocument", testDocumentText);
             var model = await _workspaceManager.GetCurrentDocumentSemanticModel(did);
-            var classConverter = _classConverterFactory.BuildMany(new Dictionary<string, string>() { { "TestNamespace.TestPage" , "PageCodeBehindClassConverter" } }, testDocumentPath, model).Single();
+            var dict = new Dictionary<string, string>() { { "TestNamespace.TestPage", "PageCodeBehindClassConverter" } ,
+                {"TestNamespace.Global", "GlobalClassConverter" },
+                { "TestNamespace.TestHandler", "HttpHandlerClassConverter"},
+                { "TestNamespace.TestModule", "HttpModuleClassConverter"},
+                { "TestNamespace.TestComponent", "ControlCodeBehindClassConverter"},
+                { "TestNamespace.TestMasterPage", "MasterPageCodeBehindClassConverter"},
+                { "TestNamespace.TestUnknownClass", "UnknownClassConverter"},
+            };
+            var classConverter = _classConverterFactory.BuildMany( dict, testDocumentPath, model).Single();
 
             Assert.IsInstanceOf(targetType, classConverter);
         }


### PR DESCRIPTION
## Related issue

WebForm application was not ported correctly


## Description
Reload the source code file which applied code replacer and generate correct semetic model


---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
