### PR TITLE
fix: handling of empty packages sequence

### DIFF
--- a/src/CTA.Rules.ProjectFile/ProjectFileCreator.cs
+++ b/src/CTA.Rules.ProjectFile/ProjectFileCreator.cs
@@ -295,10 +295,14 @@ namespace CTA.Rules.ProjectFile
                 .GroupBy(d => d.Name).Select(d => d.FirstOrDefault())
                 .ToDictionary(p => p.Name, p => p.Version);
 
-            _packages = _packages.Where(p => existingPackages.Keys?.Contains(p.Key) == false).ToDictionary(d => d.Key, d => d.Value);
+            // if packages is empty, or every key in _packages is contained in existing packages, return
+            if (_packages.Count == 0 ||
+                _packages.All(p => existingPackages.Keys?.Contains(p.Key) ?? true))
+            {
+                return;
+            }
 
-            //No packages to add
-            if (_packages.Count == 0) return;
+            _packages = _packages.Where(p => existingPackages.Keys?.Contains(p.Key) == false).ToDictionary(d => d.Key, d => d.Value);
 
             var packages = GetPackagesSection();
             if (existingPackages.Count == 0)


### PR DESCRIPTION
The call to .ToDictionary was throwing exemption if the sequence contains no elements.

## Related issue
TT: P119178698

## Description
* Shift and consolidate the check for _packages being empty earlier. We need two checks, one if _packages starts empty, or if we filter out the elements in packages because they are existing. If it has no elements, the .ToDictionary call will throw an exception.

Error: PortingAssistant.Client.PortingProjectFile.PortingProjectFileHandler: Error while creating project file for {projectfile} - System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at CTA.Rules.ProjectFile.ProjectFileCreator.<>c.<UpdatePackageReferences>b__30_1(XElement d)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Lookup`2.Create(IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)
   at System.Linq.GroupedEnumerable`2.GetEnumerator()
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at CTA.Rules.ProjectFile.ProjectFileCreator.UpdatePackageReferences()
   at CTA.Rules.ProjectFile.ProjectFileCreator.CreateContents()

## Supplemental testing
Add two unit tests that step through the new code to verify the functionality.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
